### PR TITLE
Fix typo on user delete column

### DIFF
--- a/Server/Pages/ManageOrganization.razor
+++ b/Server/Pages/ManageOrganization.razor
@@ -105,7 +105,7 @@
                             <th>Administrator</th>
                             <th>Device Groups</th>
                             <th>Reset Password</th>
-                            <th>Delete Group</th>
+                            <th>Delete User</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
Currently the column name says delete group, but the action is for deleting users, so this PR is to correct this.

---

Please read the following.  Do not delete below this line.

---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to me (Jared Goodwin) so that I retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that I'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Jared Goodwin, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
