### PR TITLE
Added null check on BrandingInfo to prevent null reference exception.

### DIFF
--- a/Desktop.Win/Services/SessionIndicatorWin.cs
+++ b/Desktop.Win/Services/SessionIndicatorWin.cs
@@ -49,7 +49,7 @@ namespace Remotely.Desktop.Win.Services
 
                     Icon icon;
 
-                    if (_deviceInitService.BrandingInfo.Icon?.Any() == true)
+                    if (_deviceInitService.BrandingInfo?.Icon?.Any() == true)
                     {
                         using var ms = new MemoryStream(_deviceInitService.BrandingInfo.Icon);
                         using var bitmap = new Bitmap(ms);


### PR DESCRIPTION
---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
