### PR TITLE
Added Get route for device groups

### DIFF
--- a/Server/API/OrganizationManagementController.cs
+++ b/Server/API/OrganizationManagementController.cs
@@ -102,7 +102,7 @@ namespace Remotely.Server.API
             }
             if (Request.Headers.TryGetValue("OrganizationID", out var orgID))
                 return Ok(DataService.GetDeviceGroupsForOrganization(orgID));
-            return BadRequest("Unable to find User or organizationID for device group");
+            return NotFound("Unable to find User or organizationID for device group");
         }
 
         [HttpDelete("DeviceGroup")]

--- a/Server/API/OrganizationManagementController.cs
+++ b/Server/API/OrganizationManagementController.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using MailKit;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
+using Org.BouncyCastle.Crypto.Agreement;
 using Remotely.Server.Auth;
 using Remotely.Server.Services;
 using Remotely.Shared.Models;
@@ -17,8 +19,8 @@ namespace Remotely.Server.API
     [ApiController]
     public class OrganizationManagementController : ControllerBase
     {
-        public OrganizationManagementController(IDataService dataService, 
-            UserManager<RemotelyUser> userManager, 
+        public OrganizationManagementController(IDataService dataService,
+            UserManager<RemotelyUser> userManager,
             IEmailSenderEx emailSender)
         {
             DataService = dataService;
@@ -87,6 +89,20 @@ namespace Remotely.Server.API
             Request.Headers.TryGetValue("OrganizationID", out var orgID);
             await DataService.DeleteUser(orgID, userID);
             return Ok("ok");
+        }
+
+        [HttpGet("DeviceGroup")]
+        [ServiceFilter(typeof(ApiAuthorizationFilter))]
+        public IActionResult DeviceGroup()
+        {
+            if (User.Identity.IsAuthenticated &&
+                DataService.GetUserByNameWithOrg(User.Identity.Name).IsAdministrator)
+            {
+                return Ok(DataService.GetDeviceGroups(User.Identity.Name));
+            }
+            if (Request.Headers.TryGetValue("OrganizationID", out var orgID))
+                return Ok(DataService.GetDeviceGroupsForOrganization(orgID));
+            return BadRequest("Unable to find User or organizationID for device group");
         }
 
         [HttpDelete("DeviceGroup")]


### PR DESCRIPTION
Added the missing Get route for device groups

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
