### PR TITLE
Base64 encode API Token

### DIFF
--- a/Server/Auth/ApiAuthorizationFilter.cs
+++ b/Server/Auth/ApiAuthorizationFilter.cs
@@ -27,13 +27,20 @@ namespace Remotely.Server.Auth
 
             if (context.HttpContext.Request.Headers.TryGetValue("Authorization", out var result))
             {
-                var tokenType = result.ToString().Split(" ")[0].Trim();
+
+                var headerComponents = result.ToString().Split(" ");
+                if (headerComponents.Length < 2)
+                {
+                    context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                    return;
+                };
+
+                var tokenType = headerComponents[0].Trim();
+                var encodedToken = headerComponents[1].Trim();
 
                 switch (tokenType)
                 {
                     case "Basic":
-                        var encodedToken = result.ToString().Split(" ")[1].Trim();
-
                         byte[] data = Convert.FromBase64String(encodedToken);
                         string decodedString = Encoding.UTF8.GetString(data);
                         var keyId = decodedString.ToString().Split(":")[0]?.Trim();

--- a/Server/Auth/ApiAuthorizationFilter.cs
+++ b/Server/Auth/ApiAuthorizationFilter.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Remotely.Server.Services;
+using System;
+using System.Text;
 
 namespace Remotely.Server.Auth
 {
@@ -25,15 +27,26 @@ namespace Remotely.Server.Auth
 
             if (context.HttpContext.Request.Headers.TryGetValue("Authorization", out var result))
             {
-                var keyId = result.ToString().Split(":")[0]?.Trim();
-                var apiSecret = result.ToString().Split(":")[1]?.Trim();
+                var tokenType = result.ToString().Split(" ")[0].Trim();
 
-                if (DataService.ValidateApiKey(keyId, apiSecret, context.HttpContext.Request.Path, context.HttpContext.Connection.RemoteIpAddress.ToString()))
+                switch (tokenType)
                 {
-                    var orgID = DataService.GetApiKey(keyId)?.OrganizationID;
-                    context.HttpContext.Request.Headers["OrganizationID"] = orgID;
-                    return;
+                    case "Basic":
+                        var encodedToken = result.ToString().Split(" ")[1].Trim();
+
+                        byte[] data = Convert.FromBase64String(encodedToken);
+                        string decodedString = Encoding.UTF8.GetString(data);
+                        var keyId = decodedString.ToString().Split(":")[0]?.Trim();
+                        var apiSecret = decodedString.ToString().Split(":")[1]?.Trim();
+                        if (DataService.ValidateApiKey(keyId, apiSecret, context.HttpContext.Request.Path, context.HttpContext.Connection.RemoteIpAddress.ToString()))
+                        {
+                            var orgID = DataService.GetApiKey(keyId)?.OrganizationID;
+                            context.HttpContext.Request.Headers["OrganizationID"] = orgID;
+                            return;
+                        }
+                        break;
                 }
+
             }
 
             context.Result = new UnauthorizedResult();


### PR DESCRIPTION
Made the authorization header require a Basic base64 encoded token instead of the literal key:secret as PowerShell 7 complains when you don't use a base64 encoded value.


---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
