### PR TITLE
Create AppDbFactory.

### DIFF
--- a/Server/Data/AppDbFactory.cs
+++ b/Server/Data/AppDbFactory.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Configuration;
+using Remotely.Server.Services;
+using System;
+
+namespace Remotely.Server.Data
+{
+    public interface IAppDbFactory
+    {
+        AppDb GetContext();
+    }
+
+    public class AppDbFactory : IAppDbFactory
+    {
+        private readonly IApplicationConfig _appConfig;
+        private readonly IConfiguration _configuration;
+
+        public AppDbFactory(IApplicationConfig appConfig, IConfiguration configuration)
+        {
+            _appConfig = appConfig;
+            _configuration = configuration;
+        }
+
+        public AppDb GetContext()
+        {
+            return _appConfig.DBProvider.ToLower() switch
+            {
+                "sqlite" => new SqliteDbContext(_configuration),
+                "sqlserver" => new SqlServerDbContext(_configuration),
+                "postgresql" => new PostgreSqlDbContext(_configuration),
+                "inmemory" => new TestingDbContext(),
+                _ => throw new ArgumentException("Unknown DB provider."),
+            };
+        }
+    }
+}

--- a/Server/Startup.cs
+++ b/Server/Startup.cs
@@ -53,7 +53,6 @@ namespace Remotely.Server
                 {
                     options.UseSqlite(Configuration.GetConnectionString("SQLite"));
                 });
-
             }
             else if (dbProvider == "sqlserver")
             {
@@ -158,6 +157,7 @@ namespace Remotely.Server
             services.AddLogging();
             services.AddScoped<IEmailSenderEx, EmailSenderEx>();
             services.AddScoped<IEmailSender, EmailSender>();
+            services.AddScoped<IAppDbFactory, AppDbFactory>();
             services.AddTransient<IDataService, DataService>();
             services.AddScoped<IApplicationConfig, ApplicationConfig>();
             services.AddScoped<ApiAuthorizationFilter>();

--- a/Tests/IoCActivator.cs
+++ b/Tests/IoCActivator.cs
@@ -64,6 +64,7 @@ namespace Remotely.Tests
              .AddDefaultUI()
              .AddDefaultTokenProviders();
 
+            services.AddTransient<IAppDbFactory, AppDbFactory>();
             services.AddTransient<IDataService, DataService>();
             services.AddTransient<IApplicationConfig, ApplicationConfig>();
             services.AddTransient<IEmailSenderEx, EmailSenderEx>();


### PR DESCRIPTION
Might as well add a DbContext factory back in.  I think @cmbankester was inferring that it's better than newing one up and breaking IoC pattern, and I agree.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
