### PR TITLE
Running container as root is not best practice

### DIFF
--- a/Server/Dockerfile-rootless
+++ b/Server/Dockerfile-rootless
@@ -1,0 +1,48 @@
+FROM ubuntu:focal
+
+EXPOSE 5000
+
+ENV ASPNETCORE_ENVIRONMENT="Production"
+ENV ASPNETCORE_URLS="http://*:5000"
+
+RUN \
+  apt-get -y update && \
+  apt-get -y install \
+  apt-utils \
+  wget \
+  apt-transport-https \
+  unzip \
+  acl \
+  libssl1.0
+
+RUN \
+  wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && \
+  dpkg -i packages-microsoft-prod.deb && \
+  apt-get -y update && \
+  apt-get -y install aspnetcore-runtime-5.0
+
+RUN \
+  adduser --disabled-password --gecos '' -u 2001 remotely && \
+  mkdir -p /var/www/remotely && \
+  mkdir /config && \
+  wget -q https://github.com/lucent-sea/Remotely/releases/latest/download/Remotely_Server_Linux-x64.zip && \
+  unzip -o Remotely_Server_Linux-x64.zip -d /var/www/remotely && \
+  rm Remotely_Server_Linux-x64.zip && \
+  chown -R remotely:remotely /var/www/remotely
+
+RUN \
+  mkdir -p /remotely-data && \
+  sed -i 's/DataSource=Remotely.db/DataSource=\/remotely-data\/Remotely.db/' /var/www/remotely/appsettings.json && \
+  chown -R remotely:remotely /remotely-data
+
+VOLUME "/remotely-data"
+
+WORKDIR /var/www/remotely
+
+COPY DockerMain.sh /
+
+RUN chmod 755 /DockerMain.sh
+
+USER remotely
+
+ENTRYPOINT ["/DockerMain.sh"]


### PR DESCRIPTION
Added rootless dockerfile option.


---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
