### PR TITLE
fix: API usage in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Remotely has a basic API, which can be browsed at https://remotely.lucency.co/sw
 
 When accessing the API from the browser on another website, you'll need to set up CORS in appsettings by adding the website origin URL to the TrustedCorsOrigins array.  If you're not familiar with how CORS works, I recommend reading up on it before proceeding.  For example, if I wanted to create a login form on https://lucency.co that logged into the Remotely API, I'd need to add "https://lucency.co" to the TrustedCorsOrigins.
 
-The API key and secret must be added to the request's Authorization header in the following format: [ApiKey]:[ApiSecret]
+The API key and secret must first be combined [ApiKey]:[ApiSecret] and then encoded with Base64 as [EncodedAuhorization]. After that you can add the encoded string to the request's Authorization header in the form "Basic [EncodedAuhorization]"
 
 Below is an example API request:
 
@@ -272,7 +272,7 @@ Below are examples of using the cookie-based login API (JavaScript):
 		method: "post",
 		credentials: "include",
 		mode: "cors",
-		body: '{"Email":"email@example.com", "Password":"P@ssword1"}',
+		body: '{"email":"email@example.com", "password":"P@ssword1"}',
 		headers: {
 			"Content-Type": "application/json",
 		}
@@ -297,7 +297,7 @@ Below are examples of using the cookie-based login API (JavaScript):
 		method: "post",
 		credentials: "include",
 		mode: "cors",
-		body: '{"Email":"email@example.com", "Password":"P@ssword1", "DeviceID":"b68c24b0-2c67-4524-ad28-dadea7a576a4"}',
+		body: '{"email":"email@example.com", "password":"P@ssword1", "deviceID":"b68c24b0-2c67-4524-ad28-dadea7a576a4"}',
 		headers: {
 			"Content-Type": "application/json",
 		}


### PR DESCRIPTION
This will correct the out-dated documentation on using the API with authorization headers. This also corrects the POST parameters used in the examples.

The issue is described here: #493 


---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
