### PR TITLE
fix: Prevent invalid authorization headers from accessing the API

### DIFF
--- a/Server/Auth/ApiAuthorizationFilter.cs
+++ b/Server/Auth/ApiAuthorizationFilter.cs
@@ -33,6 +33,7 @@ namespace Remotely.Server.Auth
                 if (headerComponents.Length < 2)
                 {
                     context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                    context.Result = new UnauthorizedResult();
                     return;
                 };
 
@@ -49,6 +50,7 @@ namespace Remotely.Server.Auth
                         if (authComponents.Length < 2)
                         {
                             context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                            context.Result = new UnauthorizedResult();
                             return;
                         };
 


### PR DESCRIPTION
The API is secured by this authorization filter that should prevent access to the API when the auhorization header is invalid. Instead the filter just set the status to 403, but delivered the data anyway.

This commit fixes this by explicitly setting the result to an UnauthorizedResult, which prevents access to the API.

#495

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
