### PR TITLE
djynntech.01

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,13 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      serverUrl:
+      serverUrl: https://assist.djynntech.com
         description: 'Server URL'     
         required: true
       rid:
         description: 'Server Runtime Identifier'     
         required: false
-        default: "linux-x64"
+        default: "win10-x64"
 
 jobs:
 
@@ -109,7 +109,7 @@ jobs:
       with:
         # Comment out the below 'repository' line if you want to build from
         # your fork instead of the author's.
-        repository: lucent-sea/Remotely
+        repository: immense/Remotely
         fetch-depth: 0
 
     # Test the Server URL to make sure it's valid


### PR DESCRIPTION
---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
