### PR TITLE
IConfiguration reload in Docker.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
           
           Write-Host "Publishing agent with version $CurrentVersion"
-          dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
+          dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --self-contained --configuration Release --output "./Agent/bin/publish/" "./Agent/"
           Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 
       - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 # IMPORTANT:
-# 1. The Server URL must include the scheme (e.g. https://app.remotely.one).
-
-# 2. The Server Runtime Identifier determines the target operating system
+# 1. The Server Runtime Identifier determines the target operating system
 # for which to build the server.  The default "linux-x64" will usually work
 # for most Linux-based operating systems.  You can see a full list at
 # https://docs.microsoft.com/en-us/dotnet/core/rid-catalog.
@@ -101,15 +99,6 @@ jobs:
         repository: immense/Remotely
         submodules: recursive
         fetch-depth: 0
-
-    # Test the Server URL to make sure it's valid
-    - name: Check Server URL Format
-      run: |
-        $Result = ""
-        if (![System.Uri]::TryCreate($env:ServerUrl, [System.UriKind]::Absolute, [ref] $Result)) {
-            throw "Server URL is not in the correct format.  It should be fully qualified with scheme and host (e.g. https://app.remotely.one)."
-        }
-        
         
     # Install the .NET Core workload
     - name: Install .NET Core
@@ -168,7 +157,7 @@ jobs:
     - name: Run Publish script
       shell: powershell
       run: |
-        .\Utilities\Publish.ps1 -CertificatePath "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx" -CertificatePassword $env:PfxKey -Hostname $env:ServerUrl -CurrentVersion $env:CurrentVersion -RID ${{ github.event.inputs.rid }} -OutDir "$env:GITHUB_WORKSPACE\publish"
+        .\Utilities\Publish.ps1 -CertificatePath "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx" -CertificatePassword $env:PfxKey -CurrentVersion $env:CurrentVersion -RID ${{ github.event.inputs.rid }} -OutDir "$env:GITHUB_WORKSPACE\publish"
         
     # Upload build artifact to be deployed from Ubuntu runner
     - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      serverUrl:
-        description: 'Server URL'     
-        required: true
       rid:
         description: 'Server Runtime Identifier'     
         required: false
@@ -57,12 +54,7 @@ jobs:
           $VersionString = git show -s --format=%ci
           $VersionDate = [DateTimeOffset]::Parse($VersionString)
 
-          $Year = $VersionDate.Year.ToString()
-          $Month = $VersionDate.Month.ToString().PadLeft(2, "0")
-          $Day = $VersionDate.Day.ToString().PadLeft(2, "0")
-          $Hour = $VersionDate.Hour.ToString().PadLeft(2, "0")
-          $Minute = $VersionDate.Minute.ToString().PadLeft(2, "0")
-          $CurrentVersion = "$Year.$Month.$Day.$Hour$Minute"
+          $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
 
           echo "CurrentVersion=$CurrentVersion" >> $env:GITHUB_ENV
 
@@ -74,12 +66,7 @@ jobs:
           $VersionString = git show -s --format=%ci
           $VersionDate = [DateTimeOffset]::Parse($VersionString)
 
-          $Year = $VersionDate.Year.ToString()
-          $Month = $VersionDate.Month.ToString().PadLeft(2, "0")
-          $Day = $VersionDate.Day.ToString().PadLeft(2, "0")
-          $Hour = $VersionDate.Hour.ToString().PadLeft(2, "0")
-          $Minute = $VersionDate.Minute.ToString().PadLeft(2, "0")
-          $CurrentVersion = "$Year.$Month.$Day.$Hour$Minute"
+          $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
           
           Write-Host "Publishing agent with version $CurrentVersion"
           dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
@@ -163,13 +150,8 @@ jobs:
       run: |
         $VersionString = git show -s --format=%ci
         $VersionDate = [DateTimeOffset]::Parse($VersionString)
-
-        $Year = $VersionDate.Year.ToString()
-        $Month = $VersionDate.Month.ToString().PadLeft(2, "0")
-        $Day = $VersionDate.Day.ToString().PadLeft(2, "0")
-        $Hour = $VersionDate.Hour.ToString().PadLeft(2, "0")
-        $Minute = $VersionDate.Minute.ToString().PadLeft(2, "0")
-        $CurrentVersion = "$Year.$Month.$Day.$Hour$Minute"
+        
+        $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
         
         echo "CurrentVersion=$CurrentVersion" >> $env:GITHUB_ENV
 

--- a/Agent.Installer.Win/Utilities/Logger.cs
+++ b/Agent.Installer.Win/Utilities/Logger.cs
@@ -6,7 +6,8 @@ namespace Remotely.Agent.Installer.Win.Utilities
 {
     public class Logger
     {
-        private static readonly string _logPath = Path.Combine(Path.GetTempPath(), "Remotely", "Installer.log");
+        private static readonly string _logDir = Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Remotely", "Logs")).FullName;
+        private static readonly string _logPath = Path.Combine(_logDir, "Installer.log");
         private static readonly object _writeLock = new object();
 
         public static void Debug(string message)

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -28,8 +28,6 @@ namespace Remotely.Agent
 
                 await Init();
 
-                _ = Task.Run(Services.GetRequiredService<AgentSocket>().HandleConnection);
-
                 await Task.Delay(-1);
 
             }
@@ -47,8 +45,11 @@ namespace Remotely.Agent
             serviceCollection.AddLogging(builder =>
             {
                 builder.AddConsole().AddDebug();
+                builder.AddProvider(new FileLoggerProvider("Remotely_Agent"));
             });
-            serviceCollection.AddSingleton<AgentSocket>();
+
+            // TODO: All these should be registered as interfaces.
+            serviceCollection.AddSingleton<IAgentHubConnection, AgentHubConnection>();
             serviceCollection.AddScoped<ChatClientService>();
             serviceCollection.AddTransient<PSCore>();
             serviceCollection.AddTransient<ExternalScriptingShell>();
@@ -106,7 +107,7 @@ namespace Remotely.Agent
 
                 await Services.GetRequiredService<IUpdater>().BeginChecking();
 
-                await Services.GetRequiredService<AgentSocket>().Connect();
+                await Services.GetRequiredService<IAgentHubConnection>().Connect();
             }
             catch (Exception ex)
             {

--- a/Desktop.Linux/Program.cs
+++ b/Desktop.Linux/Program.cs
@@ -14,7 +14,7 @@ using Immense.RemoteControl.Desktop.UI.Services;
 using Remotely.Shared;
 using System.Diagnostics;
 
-var logger = new FileLogger("Program.cs");
+var logger = new FileLogger("Remotely_Deskt", "Program.cs");
 var filePath = Process.GetCurrentProcess()?.MainModule?.FileName;
 var serverUrl = Debugger.IsAttached ? "https://localhost:5001" : string.Empty;
 var getEmbeddedResult = await EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
@@ -40,7 +40,7 @@ var provider = await Startup.UseRemoteControlClient(
 #if DEBUG
             builder.SetMinimumLevel(LogLevel.Debug);
 #endif
-            builder.AddProvider(new FileLoggerProvider());
+            builder.AddProvider(new FileLoggerProvider("Remotely_Deskt"));
         });
 
         services.AddSingleton<IOrganizationIdProvider, OrganizationIdProvider>();

--- a/Desktop.Win/Program.cs
+++ b/Desktop.Win/Program.cs
@@ -11,7 +11,7 @@ using Remotely.Shared.Services;
 using Immense.RemoteControl.Desktop.Shared.Services;
 using System.Diagnostics;
 
-var logger = new FileLogger("Program.cs");
+var logger = new FileLogger("Remotely_Desktop", "Program.cs");
 var filePath = Process.GetCurrentProcess()?.MainModule?.FileName;
 var serverUrl = Debugger.IsAttached ? "https://localhost:5001" : string.Empty;
 var getEmbeddedResult = await EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
@@ -37,7 +37,7 @@ var provider = await Startup.UseRemoteControlClient(
 #if DEBUG
             builder.SetMinimumLevel(LogLevel.Debug);
 #endif
-            builder.AddProvider(new FileLoggerProvider());
+            builder.AddProvider(new FileLoggerProvider("Remotely_Desktop"));
         });
 
         services.AddSingleton<IOrganizationIdProvider, OrganizationIdProvider>();

--- a/README.md
+++ b/README.md
@@ -55,8 +55,29 @@ docker pull immybot/remotely:latest
 docker run -d --name remotely --restart unless-stopped -p 5000:5000 -v /var/www/remotely:/remotely-data immybot/remotely:latest
 ```
 
-## Build and Debug Instructions (Windows 10)  
-The following steps will configure your Windows 10 machine for building the Remotely server and clients.
+## Alternative Hosting Methods
+Starting in 2023, Docker will be the only supported way of hosting Remotely.  Given the number of Linux distributions and other enviromental unknowns, it will be easier to create a consistently reliable deployment process if we focus on Docker.  Also, the server is now able to dynamically embed the server/organization data into the EXE while it's downloading, so hard-coding the information in a custom build is no longer necessary.
+
+Nevertheless, Remotely can still be hosted using a service manager (e.g. `systemd`) and `dotnet`.  We still provide the Linux x64 binaries in each GitHub release that will work on most major distros.  Please refer to the [official documentation](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/) that addresses most hosting scenarios.
+
+If you still need to build from source, the `Publish.ps1` script will continue to work, as it's used when building the Docker image.  Below is an example of what I was using to build and publish to my local test server before moving to Docker.
+
+Please note, no further support will be provided for these alternative hosting methods.  If you're unfamiliar with running your own ASP.NET Core app, it's recommended that you use Docker.
+
+```
+$Root = "C:\repos\Remotely"
+Set-Location -Path $Root
+$VersionString = git show -s --format=%ci
+$VersionDate = [DateTimeOffset]::Parse($VersionString)
+$CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
+
+&"$Root\Utilities\Publish.ps1" -rid ubuntu-x64 -outdir "C:\publish"
+scp -r "$Drive\publish\*" "jared@cubey:/var/www/remotely-test/"
+ssh jared@cubey sudo systemctl restart remotely-test
+```
+
+## Build and Debug Instructions (Windows 11)  
+The following steps will configure your Windows 11 machine for building the Remotely server and clients.
 * Install Visual Studio 2022.
     * Link: https://visualstudio.microsoft.com/downloads/
 	* You should have the following Workloads selected:
@@ -73,7 +94,7 @@ The following steps will configure your Windows 10 machine for building the Remo
     * Link: https://git-scm.com/downloads
 * Install the latest LTS Node:
 	* Link: https://nodejs.org/
-* Clone the git repository: `git clone https://github.com/immense/Remotely`
+* Clone the git repository: `git clone https://github.com/immense/Remotely --recurse`
 * When debugging, the agent will use a pre-defined device ID and connect to https://localhost:5001.
 * In development environment, the server will assign all connecting agents to the first organization.
 * The above two allow you to debug the agent and server together, and see your device in the list.
@@ -137,9 +158,9 @@ You can change database by changing `DBProvider` in `ApplicationOptions` to `SQL
 	* More information: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/
 
 ## Remote Control Client Requirements
-* Windows: Only the latest version of Windows 10 is tested.  Windows 7 and 8.1 should work, though performance will be reduced on Windows 7.
-	* Windows 2016/2019 should work as well, but isn't tested regularly.
-* Linux: Only Ubuntu 18.04+ is tested.
+* Windows: Only the latest version of Windows 11 is tested.  Windows 7 and 8.1 should work, though performance will be reduced on Windows 7.
+	* Windows 2019/2022 should work as well, but isn't tested regularly.
+* Linux: Only the latest LTS version of Ubuntu is tested.
 * For the Ubuntu's "quick support" client, you must first install the following dependencies:
     * libx11-dev
 	* libxrandr-dev

--- a/Server/Pages/ServerConfig.razor.cs
+++ b/Server/Pages/ServerConfig.razor.cs
@@ -1,10 +1,8 @@
-﻿using Immense.RemoteControl.Server.Abstractions;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Build.Framework;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,7 +14,6 @@ using Remotely.Shared.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -375,6 +372,11 @@ namespace Remotely.Server.Pages
             settingsJson["ConnectionStrings"] = ConnectionStrings;
 
             await System.IO.File.WriteAllTextAsync(savePath, JsonSerializer.Serialize(settingsJson, new JsonSerializerOptions() { WriteIndented = true }));
+
+            if (Configuration is IConfigurationRoot root)
+            {
+                root.Reload();
+            }
         }
         private void SetIsServerAdmin(ChangeEventArgs ev, RemotelyUser user)
         {

--- a/Shared/Extensions/StringExtensions.cs
+++ b/Shared/Extensions/StringExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Remotely.Shared.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string SanitizeFileName(this string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return string.Empty;
+            }
+
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var validChars = fileName
+                .Where(x => !invalidChars.Contains(x))
+                .ToArray();
+
+            return new string(validChars);
+        }
+
+        public static string SanitizeFileSystemPath(this string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            var invalidChars = Path.GetInvalidPathChars();
+            var validChars = path
+                .Where(x => !invalidChars.Contains(x))
+                .ToArray();
+
+            return new string(validChars);
+        }
+    }
+}

--- a/Shared/Services/FileLoggerProvider.cs
+++ b/Shared/Services/FileLoggerProvider.cs
@@ -5,10 +5,16 @@ namespace Remotely.Shared.Services
 {
     public class FileLoggerProvider : ILoggerProvider
     {
+        private readonly string _applicationName;
+
+        public FileLoggerProvider(string applicationName)
+        {
+            _applicationName = applicationName;
+        }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new FileLogger(categoryName);
+            return new FileLogger(_applicationName, categoryName);
         }
 
         public void Dispose()

--- a/Shared/Utilities/Logger.cs
+++ b/Shared/Utilities/Logger.cs
@@ -11,10 +11,32 @@ using System.Threading.Tasks;
 
 namespace Remotely.Shared.Utilities
 {
-    // TODO: Replace this with ILogger<T>.
+    [Obsolete("Please use ILogger<T> via dependency injection.")]
     public static class Logger
     {
-        private static string LogDir => Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Remotely", "Logs")).FullName;
+        private static string _logDir;
+
+        private static string LogDir
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(_logDir))
+                {
+                    return _logDir;
+                }
+
+                if (OperatingSystem.IsWindows())
+                {
+                    _logDir = Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Remotely", "Logs")).FullName;
+                }
+                else
+                {
+                    _logDir = Directory.CreateDirectory("/var/log/remotely").FullName;
+                }
+                return _logDir;
+            }
+        }
+
         private static string LogPath => Path.Combine(LogDir, $"LogFile_{DateTime.Now:yyyy-MM-dd}.log");
         private static SemaphoreSlim WriteLock { get; } = new(1, 1);
         public static void Debug(string message, [CallerMemberName] string callerName = "")

--- a/Utilities/Publish.ps1
+++ b/Utilities/Publish.ps1
@@ -35,12 +35,7 @@ if (!$CurrentVersion) {
     $VersionString = git show -s --format=%ci
     $VersionDate = [DateTimeOffset]::Parse($VersionString)
 
-    $Year = $VersionDate.Year.ToString()
-    $Month = $VersionDate.Month.ToString().PadLeft(2, "0")
-    $Day = $VersionDate.Day.ToString().PadLeft(2, "0")
-    $Hour = $VersionDate.Hour.ToString().PadLeft(2, "0")
-    $Minute = $VersionDate.Minute.ToString().PadLeft(2, "0")
-    $CurrentVersion = "$Year.$Month.$Day.$Hour$Minute"
+    $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
 
     Pop-Location
 }


### PR DESCRIPTION
This PR fixes the `IConfiguration` reload in Docker.  It wasn't happening automatically like it does when hosting bare metal.

I also cleaned up some tech debt in Agent, added to the docs, fixed the GitHub Actions build, and updated `FileLogger` to log to `C:\ProgramData\Remotely\Logs` in Windows and `/var/log/remotely` on Linux.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
