### PR TITLE
Add UseHttpLogging option in appsettings.

### DIFF
--- a/Agent/Services/AgentHubConnection.cs
+++ b/Agent/Services/AgentHubConnection.cs
@@ -196,7 +196,19 @@ namespace Remotely.Agent.Services
         {
             _logger.LogInformation("Reconnected to server.");
             var device = await _deviceInfoService.CreateDevice(_connectionInfo.DeviceID, _connectionInfo.OrganizationID);
-            _ = await _hubConnection.InvokeAsync<bool>("DeviceCameOnline", device);
+
+            if (!await _hubConnection.InvokeAsync<bool>("DeviceCameOnline", device))
+            {
+                await Connect();
+                return;
+            }
+
+            if (await CheckForServerMigration())
+            {
+                await Connect();
+                return;
+            }
+
             await _updater.CheckForUpdates();
         }
         private void RegisterMessageHandlers()

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For more information on configuring ASP.NET Core, see https://docs.microsoft.com
 * Theme: The color theme to use for the site.  Values are "Light" or "Dark".  This can also be configured per-user in Account - Options.
 * TrustedCorsOrigins: For cross-origin API requests via JavaScript.  The websites listed in this array with be allowed to make requests to the API.  This does not grant authentication, which is still required on most endpoints.
 * UseHsts: Whether ASP.NET Core will use HTTP Strict Transport Security.
+* UseHttpLogging: Enables logging for all HTTP requests.  Also enables additional log entries in `ClientDownloadsController` regarding the effective scheme, host, and remote IP address as a result of processing forwarded headers.
 
 
 ## Changing the Database

--- a/Server/API/ClientDownloadsController.cs
+++ b/Server/API/ClientDownloadsController.cs
@@ -25,16 +25,21 @@ namespace Remotely.Server.API
     [ApiController]
     public class ClientDownloadsController : ControllerBase
     {
+        private readonly IApplicationConfig _appConfig;
         private readonly IEmbeddedServerDataSearcher _embeddedDataSearcher;
-        private readonly SemaphoreSlim _fileLock = new(1,1);
+        private readonly SemaphoreSlim _fileLock = new(1, 1);
         private readonly IWebHostEnvironment _hostEnv;
-
+        private readonly ILogger<ClientDownloadsController> _logger;
         public ClientDownloadsController(
             IWebHostEnvironment hostEnv,
-            IEmbeddedServerDataSearcher embeddedDataSearcher)
+            IEmbeddedServerDataSearcher embeddedDataSearcher,
+            IApplicationConfig appConfig,
+            ILogger<ClientDownloadsController> logger)
         {
             _hostEnv = hostEnv;
             _embeddedDataSearcher = embeddedDataSearcher;
+            _appConfig = appConfig;
+            _logger = logger;
         }
 
         [HttpGet("desktop/{platformID}")]
@@ -138,6 +143,8 @@ namespace Remotely.Server.API
 
         private async Task<IActionResult> GetDesktopFile(string filePath, string organizationId = null)
         {
+            LogRequest(nameof(GetDesktopFile));
+
             var serverUrl = $"{Request.Scheme}://{Request.Host}";
             var embeddedData = new EmbeddedServerData(new Uri(serverUrl), organizationId);
             var result = await _embeddedDataSearcher.GetRewrittenStream(filePath, embeddedData);
@@ -152,65 +159,81 @@ namespace Remotely.Server.API
 
         private async Task<IActionResult> GetInstallFile(string organizationId, string platformID)
         {
+            LogRequest(nameof(GetInstallFile));
+
+            if (!await _fileLock.WaitAsync(TimeSpan.FromSeconds(15)))
+            {
+                return StatusCode(StatusCodes.Status408RequestTimeout);
+            }
+
             try
             {
-                if (await _fileLock.WaitAsync(TimeSpan.FromSeconds(15)))
+                switch (platformID)
                 {
-                    switch (platformID)
-                    {
-                        case "WindowsInstaller":
+                    case "WindowsInstaller":
+                        {
+                            var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Remotely_Installer.exe");
+                            var serverUrl = $"{Request.Scheme}://{Request.Host}";
+                            var embeddedData = new EmbeddedServerData(new Uri(serverUrl), organizationId);
+                            var result = await _embeddedDataSearcher.GetRewrittenStream(filePath, embeddedData);
+
+                            if (!result.IsSuccess)
                             {
-                                var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Remotely_Installer.exe");
-                                var serverUrl = $"{Request.Scheme}://{Request.Host}";
-                                var embeddedData = new EmbeddedServerData(new Uri(serverUrl), organizationId);
-                                var result = await _embeddedDataSearcher.GetRewrittenStream(filePath, embeddedData);
-
-                                if (!result.IsSuccess)
-                                {
-                                    throw result.Exception;
-                                }
-
-                                return File(result.Value, "application/octet-stream", "Remotely_Installer.exe");
+                                throw result.Exception;
                             }
-                        case "ManjaroInstaller-x64":
-                            {
-                                var fileName = "Install-Manjaro-x64.sh";
 
-                                return await GetBashInstaller(fileName, organizationId);
-                            }
-                        case "UbuntuInstaller-x64":
-                            {
-                                var fileName = "Install-Ubuntu-x64.sh";
+                            return File(result.Value, "application/octet-stream", "Remotely_Installer.exe");
+                        }
+                    case "ManjaroInstaller-x64":
+                        {
+                            var fileName = "Install-Manjaro-x64.sh";
 
-                                return await GetBashInstaller(fileName, organizationId);
-                            }
-                        case "MacOSInstaller-x64":
-                            {
-                                var fileName = "Install-MacOS-x64.sh";
+                            return await GetBashInstaller(fileName, organizationId);
+                        }
+                    case "UbuntuInstaller-x64":
+                        {
+                            var fileName = "Install-Ubuntu-x64.sh";
 
-                                return await GetBashInstaller(fileName, organizationId);
-                            }
-                        case "MacOSInstaller-arm64":
-                            {
-                                var fileName = "Install-MacOS-arm64.sh";
+                            return await GetBashInstaller(fileName, organizationId);
+                        }
+                    case "MacOSInstaller-x64":
+                        {
+                            var fileName = "Install-MacOS-x64.sh";
 
-                                return await GetBashInstaller(fileName, organizationId);
-                            }
-                        default:
-                            return BadRequest();
-                    }
-                }
-                else
-                {
-                    return StatusCode(StatusCodes.Status408RequestTimeout);
+                            return await GetBashInstaller(fileName, organizationId);
+                        }
+                    case "MacOSInstaller-arm64":
+                        {
+                            var fileName = "Install-MacOS-arm64.sh";
+
+                            return await GetBashInstaller(fileName, organizationId);
+                        }
+                    default:
+                        return BadRequest();
                 }
             }
             finally
             {
-                if (_fileLock.CurrentCount == 0)
+                _fileLock.Release();
+            }
+        }
+
+        private void LogRequest(string methodName)
+        {
+            if (_appConfig.UseHttpLogging)
+            {
+                var ip = Request.HttpContext.Connection.RemoteIpAddress;
+                if (ip?.IsIPv4MappedToIPv6 == true)
                 {
-                    _fileLock.Release();
+                    ip = ip.MapToIPv4();
                 }
+
+                _logger.LogInformation(
+                    "Started client download via {methodName}.  Effective Scheme: {scheme}.  Effective Host: {host}.  Remote IP: {ip}.",
+                    methodName,
+                    Request.Scheme,
+                    Request.Host,
+                    $"{ip}");
             }
         }
     }

--- a/Server/Pages/ServerConfig.razor
+++ b/Server/Pages/ServerConfig.razor
@@ -338,10 +338,12 @@
                     <ValidationMessage For="() => Input.UseHsts" />
                 </div>
 
-                <div class="form-group">
-                    <label>ICE Servers</label>
+                 <div class="form-group">
+                    <label>Use HTTP Logging</label>
                     <br />
-                    <span class="text-muted">Must be edited in appsettings.json.</span>
+                    <InputCheckbox @bind-Value="Input.UseHttpLogging" autocomplete="off" />
+                    <br />
+                    <ValidationMessage For="() => Input.UseHttpLogging" />
                 </div>
 
                 <h4>Connection Strings</h4>

--- a/Server/Pages/ServerConfig.razor.cs
+++ b/Server/Pages/ServerConfig.razor.cs
@@ -103,6 +103,9 @@ namespace Remotely.Server.Pages
 
         [Display(Name = "Use HSTS")]
         public bool UseHsts { get; set; }
+
+        [Display(Name = "Use HTTP Logging")]
+        public bool UseHttpLogging { get; set; }
     }
 
     public class ConnectionStringsModel

--- a/Server/Pages/ServerLogs.razor
+++ b/Server/Pages/ServerLogs.razor
@@ -78,7 +78,7 @@
                     <td>
                         @if (!string.IsNullOrWhiteSpace(eventLog.Message))
                         {
-                            foreach (var line in eventLog.Message.Split("\n"))
+                            foreach (var line in eventLog.Message.Split("\n", StringSplitOptions.RemoveEmptyEntries))
                             {
                                 <div>@line</div>
                             }

--- a/Server/Pages/ServerLogs.razor
+++ b/Server/Pages/ServerLogs.razor
@@ -75,7 +75,15 @@
                 <tr @key="eventLog">
                     <td>@eventLog.EventType</td>
                     <td>@eventLog.TimeStamp</td>
-                    <td>@eventLog.Message</td>
+                    <td>
+                        @if (!string.IsNullOrWhiteSpace(eventLog.Message))
+                        {
+                            foreach (var line in eventLog.Message.Split("\n"))
+                            {
+                                <div>@line</div>
+                            }
+                        }
+                    </td>
                     <td>@eventLog.Source</td>
                     <td>@eventLog.StackTrace</td>
                 </tr>

--- a/Server/Pages/ServerLogs.razor
+++ b/Server/Pages/ServerLogs.razor
@@ -19,13 +19,13 @@
         </div>
         <div>
             <button class="btn btn-primary"
-                    onclick="location.assign('/API/ServerLogs/Download')">
+                    onclick="window.open('/API/ServerLogs/Download', '_blank')">
                 Download Logs
             </button>
         </div>
         <div>
             <button class="btn btn-primary"
-                    onclick="location.assign('/API/ScriptResults')">
+                    onclick="window.open('/API/ScriptResults', '_blank')">
                 Download Script History
             </button>
         </div>

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -115,6 +115,9 @@ services.AddHttpLogging(options =>
     options.RequestHeaders.Add("X-Forwarded-For");
     options.RequestHeaders.Add("X-Forwarded-Proto");
     options.RequestHeaders.Add("X-Forwarded-Host");
+    options.RequestHeaders.Add("X-Original-For");
+    options.RequestHeaders.Add("X-Original-Proto");
+    options.RequestHeaders.Add("X-Original-Host");
     options.RequestHeaders.Add("Host");
 });
 

--- a/Server/Services/ApplicationConfig.cs
+++ b/Server/Services/ApplicationConfig.cs
@@ -34,6 +34,7 @@ namespace Remotely.Server.Services
         Theme Theme { get; }
         string[] TrustedCorsOrigins { get; }
         bool UseHsts { get; }
+        bool UseHttpLogging { get; }
     }
 
     public class ApplicationConfig : IApplicationConfig
@@ -70,6 +71,7 @@ namespace Remotely.Server.Services
         public Theme Theme => Enum.Parse<Theme>(Config["ApplicationOptions:Theme"] ?? "Dark", true);
         public string[] TrustedCorsOrigins => Config.GetSection("ApplicationOptions:TrustedCorsOrigins").Get<string[]>() ?? System.Array.Empty<string>();
         public bool UseHsts => bool.Parse(Config["ApplicationOptions:UseHsts"] ?? "false");
+        public bool UseHttpLogging => bool.Parse(Config["ApplicationOptions:UseHttpLogging"] ?? "false");
         private IConfiguration Config { get; set; }
     }
 }

--- a/Server/appsettings.Development.json
+++ b/Server/appsettings.Development.json
@@ -2,6 +2,7 @@
   "DetailedErrors": true,
   "Logging": {
     "LogLevel": {
+      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"

--- a/Server/appsettings.Development.json
+++ b/Server/appsettings.Development.json
@@ -2,7 +2,6 @@
   "DetailedErrors": true,
   "Logging": {
     "LogLevel": {
-      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -37,6 +37,6 @@
     "Theme": "Dark",
     "TrustedCorsOrigins": [],
     "UseHsts": false,
-    "UseHttpLogging": true
+    "UseHttpLogging": false
   }
 }

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -6,6 +6,7 @@
   },
   "Logging": {
     "LogLevel": {
+      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
       "Default": "Warning"
     }
   },
@@ -35,6 +36,7 @@
     "SmtpUserName": "",
     "Theme": "Dark",
     "TrustedCorsOrigins": [],
-    "UseHsts": false
+    "UseHsts": false,
+    "UseHttpLogging": true
   }
 }

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -7,7 +7,7 @@
   "Logging": {
     "LogLevel": {
       "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
-      "Default": "Warning"
+      "Default": "Information"
     }
   },
   "ApplicationOptions": {


### PR DESCRIPTION
This PR adds `UseHttpLogging` option to the appsettings.  If enabled, ASP.NET Core's built-in HTTP logging will be enabled, and additional log entries will be made in `ClientDownloadsController` regarding the effective scheme, host, and remote IP (i.e. the results of processed forwarded headers).

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
