### PR TITLE
Move HTTP logging above forwarded headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ To avoid injection attacks, ASP.NET Core defaults to only accepting forwarded he
     - People will no longer be able to create accounts on their own.
     - To allow self-registration, increase the `MaxOrganizationCount` or set it to -1 (see Configuration section).
 
-
 ## Update the Docker Container
 ```
 docker stop remotely
@@ -59,6 +58,13 @@ docker rm remotely
 docker pull immybot/remotely:latest
 docker run -d --name remotely --restart unless-stopped -p 5000:5000 -v /var/www/remotely:/remotely-data immybot/remotely:latest
 ```
+
+## HTTP Logging
+You can enable HTTP logging to see all requests and responses in the server logs, including headers.  This can be helpful for debugging reverse proxy, API, or SignalR issues.  The option can be enabled it `appsettings.json` or the Server Config page.
+
+You must explicitly set a log level for `Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware` for this to work.  See the [appsettings.json](https://github.com/immense/Remotely/blob/master/Server/appsettings.json) file for an example.
+
+After changing the above, you must restart the container for the changes to take effect.
 
 ## Alternative Hosting Methods
 Starting in 2023, Docker will be the only supported way of hosting Remotely.  Given the number of Linux distributions and other enviromental unknowns, it will be easier to create a consistently reliable deployment process if we focus on Docker.  Also, the server is now able to dynamically embed the server/organization data into the EXE while it's downloading, so hard-coding the information in a custom build is no longer necessary.
@@ -118,12 +124,6 @@ However, the clients will need to have been built from source with the server UR
 ## Configuration
 The following settings are available in appsettings.json, under the ApplicationOptions section.
 
-When deployed to production, the application will use the `appsettings.Production.json` file, if it's present. To retain your settings between upgrades, copy your `appsettings.json` file to `appsettings.Production.json` on your production server, then make your configuration changes.
-
-Likewise, `appsettings.Development.json` can be used while developing in Visual Studio to override the other.
-
-Whenever there's a reference to `appsettings.json` in this document, it refers to whichever file is currently being used.
-
 For more information on configuring ASP.NET Core, see https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/.
 
 * AllowApiLogin: Whether to allow logging in via the API controller.  API access tokens are recommended over this approach.
@@ -151,7 +151,7 @@ For more information on configuring ASP.NET Core, see https://docs.microsoft.com
 ## Changing the Database
 By default, Remotely uses a SQLite database.  When first run, it creates a file as specified for the SQLite connection string in appsettings.json.
 
-You can change database by changing `DBProvider` in `ApplicationOptions` to `SQLServer` or `PostgreSQL`.  Be sure to set the connection string for the new database provider in the server's `appsettings.Production.json`.
+You can change database by changing `DBProvider` in `ApplicationOptions` to `SQLServer` or `PostgreSQL`.
 
 ## Logging
 * On clients, logs are kept in %temp%\Remotely_Logs.log.

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -213,12 +213,12 @@ services.AddSingleton<IServiceHubSessionCache, ServiceHubSessionCache>();
 var app = builder.Build();
 var appConfig = app.Services.GetRequiredService<IApplicationConfig>();
 
-app.UseForwardedHeaders();
-
 if (appConfig.UseHttpLogging)
 {
     app.UseHttpLogging();
 }
+
+app.UseForwardedHeaders();
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
This PR moves the HTTP logging middleware above forwarded headers in the pipeline, so the unmodified headers are logged.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
