### PR TITLE
Fixed linux namespace

### DIFF
--- a/Desktop.Linux/Program.cs
+++ b/Desktop.Linux/Program.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using System.Threading;
 using System;
-using Immense.RemoteControl.Desktop.Windows;
+using Immense.RemoteControl.Desktop.Linux;
 using Remotely.Desktop.Shared.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
 Depends on PR: https://github.com/immense/RemoteControl/pull/2



Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
