### PR TITLE
Add healthcheck controller with loopback-only authorization filter.

### DIFF
--- a/Server/API/HealthCheckController.cs
+++ b/Server/API/HealthCheckController.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Remotely.Server.Auth;
+using Remotely.Server.Services;
+using System.Threading.Tasks;
+
+namespace Remotely.Server.API
+{
+    /// <summary>
+    /// Can only be accessed from the local machine.  The sole purpose
+    /// is to provide a healthcheck endpoint for Docker that exercises
+    /// the database connection.
+    /// </summary>
+    [Route("api/[controller]")]
+    [ApiController]
+    [ServiceFilter(typeof(LocalOnlyFilter))]
+    public class HealthCheckController : ControllerBase
+    {
+        private readonly IDataService _dataService;
+
+        public HealthCheckController(IDataService dataService)
+        {
+            _dataService = dataService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var orgCount = await _dataService.GetOrganizationCountAsync();
+            return Ok($"Organization Count: {orgCount}");
+        }
+    }
+}

--- a/Server/Auth/LocalOnlyFilter.cs
+++ b/Server/Auth/LocalOnlyFilter.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Net;
+
+namespace Remotely.Server.Auth
+{
+    public class LocalOnlyFilter : IAuthorizationFilter
+    {
+        public void OnAuthorization(AuthorizationFilterContext context)
+        {
+            var remoteIp = context.HttpContext.Connection.RemoteIpAddress;
+            if (!IPAddress.IsLoopback(remoteIp))
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+        }
+    }
+}

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -13,6 +13,8 @@ COPY /_immense.Remotely/Server/linux-x64/Server /app
 WORKDIR /app
 
 RUN \
+  apt-get -y update && \
+  apt-get -y install curl && \
   mkdir -p /remotely-data && \
   sed -i 's/DataSource=Remotely.db/DataSource=\/remotely-data\/Remotely.db/' /app/appsettings.json
 
@@ -23,4 +25,4 @@ RUN chmod +x "/src/DockerMain.sh"
 ENTRYPOINT ["/src/DockerMain.sh"]
 
 HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost:5000/ || exit 1
+  CMD curl -f http://localhost:5000/api/healthcheck || exit 1

--- a/Server/Dockerfile.local
+++ b/Server/Dockerfile.local
@@ -16,6 +16,8 @@ COPY ./DockerMain.sh .
 WORKDIR /app
 
 RUN \
+  apt-get -y update && \
+  apt-get -y install curl && \
   mkdir -p /remotely-data && \
   sed -i 's/DataSource=Remotely.db/DataSource=\/remotely-data\/Remotely.db/' ./appsettings.json
 
@@ -24,3 +26,6 @@ VOLUME "/remotely-data"
 RUN chmod +x "/src/DockerMain.sh"
 
 ENTRYPOINT ["/src/DockerMain.sh"]
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:5000/api/healthcheck || exit 1

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -180,6 +180,7 @@ services.AddScoped<IAppDbFactory, AppDbFactory>();
 services.AddTransient<IDataService, DataService>();
 services.AddSingleton<IApplicationConfig, ApplicationConfig>();
 services.AddScoped<ApiAuthorizationFilter>();
+services.AddScoped<LocalOnlyFilter>();
 services.AddScoped<ExpiringTokenFilter>();
 services.AddHostedService<DbCleanupService>();
 services.AddHostedService<ScriptScheduler>();

--- a/Server/Services/DataService.cs
+++ b/Server/Services/DataService.cs
@@ -143,6 +143,7 @@ namespace Remotely.Server.Services
         Task<Organization> GetOrganizationByUserName(string userName);
 
         int GetOrganizationCount();
+        Task<int> GetOrganizationCountAsync();
 
         string GetOrganizationNameById(string organizationID);
 
@@ -1397,6 +1398,13 @@ namespace Remotely.Server.Services
             using var dbContext = _appDbFactory.GetContext();
 
             return dbContext.Organizations.Count();
+        }
+
+        public async Task<int> GetOrganizationCountAsync()
+        {
+            using var dbContext = _appDbFactory.GetContext();
+
+            return await dbContext.Organizations.CountAsync();
         }
 
         public string GetOrganizationNameById(string organizationID)


### PR DESCRIPTION
- Added a healthcheck controller that has a loopback-only authorization filter.
  - The action exercises the database connection by getting the org count.
- Install curl in the Dockerfile.

Resolves #592 

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
