### PR TITLE
Update submodule.

### DIFF
--- a/Server/Services/RcImplementations/HubEventHandler.cs
+++ b/Server/Services/RcImplementations/HubEventHandler.cs
@@ -62,6 +62,21 @@ namespace Remotely.Server.Services.RcImplementations
             return _serviceHub.Clients.Client(ex.AgentConnectionId).SendAsync("CtrlAltDel");
         }
 
+        public Task NotifyDesktopSessionAdded(RemoteControlSession sessionInfo)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task NotifyDesktopSessionDisposed(RemoteControlSession sessionInfo)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task NotifyDesktopSessionRemoved(RemoteControlSession sessionInfo)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task NotifyRemoteControlEnded(RemoteControlSession sessionInfo)
         {
             return Task.CompletedTask;


### PR DESCRIPTION
Catch up Remotely with submodule.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
