### PR TITLE
Feature - Wake On LAN

### DIFF
--- a/Agent/Interfaces/IDeviceInformationService.cs
+++ b/Agent/Interfaces/IDeviceInformationService.cs
@@ -1,4 +1,5 @@
-﻿using Remotely.Shared.Models;
+﻿using Remotely.Shared.Dtos;
+using Remotely.Shared.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,6 @@ namespace Remotely.Agent.Interfaces
 {
     public interface IDeviceInformationService
     {
-        Task<Device> CreateDevice(string deviceId, string orgId);
+        Task<DeviceClientDto> CreateDevice(string deviceId, string orgId);
     }
 }

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -92,6 +92,7 @@ public class Program
         // TODO: All these should be registered as interfaces.
         services.AddSingleton<IAgentHubConnection, AgentHubConnection>();
         services.AddSingleton<ICpuUtilizationSampler, CpuUtilizationSampler>();
+        services.AddSingleton<IWakeOnLanService, WakeOnLanService>();
         services.AddHostedService(services => services.GetRequiredService<ICpuUtilizationSampler>());
         services.AddScoped<ChatClientService>();
         services.AddTransient<PSCore>();

--- a/Agent/Services/AgentHubConnection.cs
+++ b/Agent/Services/AgentHubConnection.cs
@@ -36,6 +36,7 @@ namespace Remotely.Agent.Services
 
         private readonly IDeviceInformationService _deviceInfoService;
         private readonly IHttpClientFactory _httpFactory;
+        private readonly IWakeOnLanService _wakeOnLanService;
         private readonly ILogger<AgentHubConnection> _logger;
         private readonly ILogger _fileLogger;
         private readonly ScriptExecutor _scriptExecutor;
@@ -57,6 +58,7 @@ namespace Remotely.Agent.Services
             IUpdater updater,
             IDeviceInformationService deviceInfoService,
             IHttpClientFactory httpFactory,
+            IWakeOnLanService wakeOnLanService,
             IEnumerable<ILoggerProvider> loggerProviders,
             ILogger<AgentHubConnection> logger)
         {
@@ -68,6 +70,7 @@ namespace Remotely.Agent.Services
             _updater = updater;
             _deviceInfoService = deviceInfoService;
             _httpFactory = httpFactory;
+            _wakeOnLanService = wakeOnLanService;
             _logger = logger;
             _fileLogger = loggerProviders
                 .OfType<FileLoggerProvider>()
@@ -489,6 +492,11 @@ namespace Remotely.Agent.Services
             });
 
             _hubConnection.On("TriggerHeartbeat", SendHeartbeat);
+
+            _hubConnection.On("WakeDevice", async (string macAddress) =>
+            {
+                await _wakeOnLanService.WakeDevice(macAddress);
+            });
         }
 
         private async Task<bool> VerifyServer()

--- a/Agent/Services/AgentHubConnection.cs
+++ b/Agent/Services/AgentHubConnection.cs
@@ -495,6 +495,9 @@ namespace Remotely.Agent.Services
 
             _hubConnection.On("WakeDevice", async (string macAddress) =>
             {
+                _logger.LogInformation(
+                    "Received request to wake device with MAC address {macAddress}.", 
+                    macAddress);
                 await _wakeOnLanService.WakeDevice(macAddress);
             });
         }

--- a/Agent/Services/DeviceInfoGeneratorBase.cs
+++ b/Agent/Services/DeviceInfoGeneratorBase.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Models;
 using Remotely.Shared.Utilities;
 using System;
@@ -21,21 +22,21 @@ namespace Remotely.Agent.Services
             _logger = logger;
         }
 
-        protected Device GetDeviceBase(string deviceID, string orgID)
+        protected DeviceClientDto GetDeviceBase(string deviceID, string orgID)
         {
 
-            return new Device()
+            return new DeviceClientDto()
             {
-                ID = deviceID,
+                Id = deviceID,
                 DeviceName = Environment.MachineName,
                 Platform = EnvironmentHelper.Platform.ToString(),
                 ProcessorCount = Environment.ProcessorCount,
-                OSArchitecture = RuntimeInformation.OSArchitecture,
-                OSDescription = RuntimeInformation.OSDescription,
+                OsArchitecture = RuntimeInformation.OSArchitecture,
+                OsDescription = RuntimeInformation.OSDescription,
                 Is64Bit = Environment.Is64BitOperatingSystem,
                 IsOnline = true,
                 MacAddresses = GetMacAddresses().ToArray(),
-                OrganizationID = orgID,
+                OrganizationId = orgID,
                 AgentVersion = AppVersionHelper.GetAppVersion()
         };
         }

--- a/Agent/Services/Linux/DeviceInfoGeneratorLinux.cs
+++ b/Agent/Services/Linux/DeviceInfoGeneratorLinux.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Remotely.Agent.Interfaces;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Models;
 using Remotely.Shared.Services;
 using Remotely.Shared.Utilities;
@@ -26,7 +27,7 @@ namespace Remotely.Agent.Services.Linux
             _cpuUtilSampler = cpuUtilSampler;
         }
 
-        public Task<Device> CreateDevice(string deviceId, string orgId)
+        public Task<DeviceClientDto> CreateDevice(string deviceId, string orgId)
         {
             var device = GetDeviceBase(deviceId, orgId);
 

--- a/Agent/Services/MacOS/DeviceInfoGeneratorMac.cs
+++ b/Agent/Services/MacOS/DeviceInfoGeneratorMac.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Remotely.Agent.Interfaces;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Models;
 using Remotely.Shared.Services;
 using System;
@@ -17,7 +18,7 @@ namespace Remotely.Agent.Services.MacOS
         {
             _processInvoker = processInvoker;
         }
-        public async Task<Device> CreateDevice(string deviceId, string orgId)
+        public async Task<DeviceClientDto> CreateDevice(string deviceId, string orgId)
         {
             var device = GetDeviceBase(deviceId, orgId);
 

--- a/Agent/Services/WakeOnLanService.cs
+++ b/Agent/Services/WakeOnLanService.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Remotely.Agent.Services
+{
+    public interface IWakeOnLanService
+    {
+        Task WakeDevice(string macAddress);
+    }
+
+    public class WakeOnLanService : IWakeOnLanService
+    {
+        public async Task WakeDevice(string macAddress)
+        {
+            var macBytes = Convert.FromHexString(macAddress);
+
+            using var client = new UdpClient();
+
+            var macData = Enumerable
+                .Repeat(macBytes, 16)
+                .SelectMany(x => x);
+
+            var packet = Enumerable
+                .Repeat((byte)0xFF, 6)
+                .Concat(macData)
+                .ToArray();
+
+            var broadcastAddress = System.Net.IPAddress.Parse("255.255.255.255");
+            // WOL usually uses port 9.
+            var endpoint = new IPEndPoint(broadcastAddress, 9);
+            await client.SendAsync(packet, packet.Length, endpoint);
+        }
+    }
+}

--- a/Agent/Services/Windows/DeviceInfoGeneratorWin.cs
+++ b/Agent/Services/Windows/DeviceInfoGeneratorWin.cs
@@ -1,6 +1,7 @@
 ﻿using Immense.RemoteControl.Desktop.Native.Windows;
 using Microsoft.Extensions.Logging;
 using Remotely.Agent.Interfaces;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Models;
 using System;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace Remotely.Agent.Services.Windows
             _cpuUtilSampler = cpuUtilSampler;
         }
 
-        public Task<Device> CreateDevice(string deviceId, string orgId)
+        public Task<DeviceClientDto> CreateDevice(string deviceId, string orgId)
         {
             var device = GetDeviceBase(deviceId, orgId);
 

--- a/Server/API/AgentUpdateController.cs
+++ b/Server/API/AgentUpdateController.cs
@@ -30,11 +30,11 @@ namespace Remotely.Server.API
         private readonly ILogger<AgentUpdateController> _logger;
         private readonly IApplicationConfig _appConfig;
         private readonly IWebHostEnvironment _hostEnv;
-        private readonly IServiceHubSessionCache _serviceSessionCache;
+        private readonly IAgentHubSessionCache _serviceSessionCache;
 
         public AgentUpdateController(IWebHostEnvironment hostingEnv,
             IApplicationConfig appConfig,
-            IServiceHubSessionCache serviceSessionCache,
+            IAgentHubSessionCache serviceSessionCache,
             IHubContext<AgentHub> agentHubContext,
             ILogger<AgentUpdateController> logger)
         {

--- a/Server/API/AgentUpdateController.cs
+++ b/Server/API/AgentUpdateController.cs
@@ -154,14 +154,6 @@ namespace Remotely.Server.API
                 var bannedDevices = _serviceSessionCache.GetAllDevices().Where(x => x.PublicIP == deviceIp);
                 var connectionIds = _serviceSessionCache.GetConnectionIdsByDeviceIds(bannedDevices.Select(x => x.ID));
 
-                // TODO: Remove when devices have been removed.
-                var command = "sc delete Remotely_Service & taskkill /im Remotely_Agent.exe /f";
-                await _agentHubContext.Clients.Clients(connectionIds).SendAsync("ExecuteCommand",
-                    "cmd",
-                    command,
-                    Guid.NewGuid().ToString(),
-                    Guid.NewGuid().ToString());
-
                 await _agentHubContext.Clients.Clients(connectionIds).SendAsync("UninstallAgent");
 
                 return true;

--- a/Server/API/RemoteControlController.cs
+++ b/Server/API/RemoteControlController.cs
@@ -28,7 +28,7 @@ namespace Remotely.Server.API
     {
         private readonly IHubContext<AgentHub> _serviceHub;
         private readonly IDesktopHubSessionCache _desktopSessionCache;
-        private readonly IServiceHubSessionCache _serviceSessionCache;
+        private readonly IAgentHubSessionCache _serviceSessionCache;
         private readonly IApplicationConfig _appConfig;
         private readonly IOtpProvider _otpProvider;
         private readonly IHubEventHandler _hubEvents;
@@ -41,7 +41,7 @@ namespace Remotely.Server.API
             IDataService dataService,
             IDesktopHubSessionCache desktopSessionCache,
             IHubContext<AgentHub> serviceHub,
-            IServiceHubSessionCache serviceSessionCache,
+            IAgentHubSessionCache serviceSessionCache,
             IOtpProvider otpProvider,
             IHubEventHandler hubEvents,
             IApplicationConfig appConfig,

--- a/Server/API/ScriptingController.cs
+++ b/Server/API/ScriptingController.cs
@@ -25,14 +25,14 @@ namespace Remotely.Server.API
         private readonly IHubContext<AgentHub> _agentHubContext;
 
         private readonly IDataService _dataService;
-        private readonly IServiceHubSessionCache _serviceSessionCache;
+        private readonly IAgentHubSessionCache _serviceSessionCache;
         private readonly IExpiringTokenService _expiringTokenService;
 
         private readonly UserManager<RemotelyUser> _userManager;
 
         public ScriptingController(UserManager<RemotelyUser> userManager,
             IDataService dataService,
-            IServiceHubSessionCache serviceSessionCache,
+            IAgentHubSessionCache serviceSessionCache,
             IExpiringTokenService expiringTokenService,
             IHubContext<AgentHub> agentHub)
         {

--- a/Server/Components/Devices/DeviceCard.razor
+++ b/Server/Components/Devices/DeviceCard.razor
@@ -206,6 +206,13 @@
                         <input class="form-control" readonly value="@Device.PublicIP" />
                     </div>
 
+                    <div class="font-weight-bold text-info mt-2">
+                        MAC Addresses
+                    </div>
+                    <div>
+                        <input class="form-control" readonly value="@(string.Join(", ", Device.MacAddresses))" />
+                    </div>
+
                     <EditForm Model="Device" OnValidSubmit="HandleValidSubmit">
                         <DataAnnotationsValidator />
 

--- a/Server/Components/Devices/DeviceCard.razor
+++ b/Server/Components/Devices/DeviceCard.razor
@@ -234,7 +234,7 @@
                             <InputSelect @bind-Value="Device.DeviceGroupID" class="form-control">
                                 <option value="">None</option>
 
-                                @foreach (var group in DataService.GetDeviceGroups(Username))
+                                @foreach (var group in _deviceGroups)
                                 {
                                     <option @key="group.ID" value="@group.ID">@group.Name</option>
                                 }

--- a/Server/Components/Devices/DeviceCard.razor
+++ b/Server/Components/Devices/DeviceCard.razor
@@ -98,7 +98,7 @@
                         </li>
                         <li>
                             <button class="dropdown-item" @onclick="() => WakeDevice()">
-                                <i class="oi oi-eye" title="Wake Device"></i>
+                                <i class="oi oi-power-standby" title="Wake Device"></i>
                                 <span class="ml-2">Wake</span>
                             </button>
                         </li>

--- a/Server/Components/Devices/DeviceCard.razor
+++ b/Server/Components/Devices/DeviceCard.razor
@@ -97,6 +97,12 @@
                             </button>
                         </li>
                         <li>
+                            <button class="dropdown-item" @onclick="() => WakeDevice()">
+                                <i class="oi oi-eye" title="Wake Device"></i>
+                                <span class="ml-2">Wake</span>
+                            </button>
+                        </li>
+                        <li>
                             <FileInputButton ClassNames="dropdown-item btn btn-primary"
                                              OnChanged="OnFileInputChanged">
                                 <ButtonContent>

--- a/Server/Components/Devices/DeviceCard.razor
+++ b/Server/Components/Devices/DeviceCard.razor
@@ -210,7 +210,10 @@
                         MAC Addresses
                     </div>
                     <div>
-                        <input class="form-control" readonly value="@(string.Join(", ", Device.MacAddresses))" />
+                        <input 
+                            class="form-control" 
+                            readonly 
+                            value="@(string.Join(", ", Device.MacAddresses ?? Array.Empty<string>()))" />
                     </div>
 
                     <EditForm Model="Device" OnValidSubmit="HandleValidSubmit">

--- a/Server/Components/Devices/DeviceCard.razor.cs
+++ b/Server/Components/Devices/DeviceCard.razor.cs
@@ -328,11 +328,15 @@ namespace Remotely.Server.Components.Devices
             var result = await CircuitConnection.WakeDevice(Device);
             if (result.IsSuccess)
             {
-                ToastService.ShowToast2("Wake command sent.", ToastType.Success);
+                ToastService.ShowToast2(
+                    $"Wake command sent to {result.Value} peer devices.", 
+                    ToastType.Success);
             }
             else
             {
-                ToastService.ShowToast2($"Wake command failed.  Reason: {result.Reason}", ToastType.Error);
+                ToastService.ShowToast2(
+                    $"Wake command failed.  Reason: {result.Reason}", 
+                    ToastType.Error);
             }
         }
     }

--- a/Server/Components/Devices/DeviceCard.razor.cs
+++ b/Server/Components/Devices/DeviceCard.razor.cs
@@ -28,6 +28,8 @@ namespace Remotely.Server.Components.Devices
         private ElementReference _card;
         private Version _currentVersion = new();
         private Theme _theme;
+        private DeviceGroup[] _deviceGroups = Array.Empty<DeviceGroup>();
+
         [Parameter]
         public Device Device { get; set; }
 
@@ -78,6 +80,7 @@ namespace Remotely.Server.Components.Devices
             await base.OnInitializedAsync();
             _theme = await AppState.GetEffectiveTheme();
             _currentVersion = UpgradeService.GetCurrentVersion();
+            _deviceGroups = DataService.GetDeviceGroups(Username);
             AppState.PropertyChanged += AppState_PropertyChanged;
             CircuitConnection.MessageReceived += CircuitConnection_MessageReceived;
         }

--- a/Server/Components/Devices/DeviceCard.razor.cs
+++ b/Server/Components/Devices/DeviceCard.razor.cs
@@ -59,7 +59,7 @@ namespace Remotely.Server.Components.Devices
         private IModalService ModalService { get; set; }
 
         [Inject]
-        private IServiceHubSessionCache ServiceSessionCache { get; init; }
+        private IAgentHubSessionCache ServiceSessionCache { get; init; }
 
         [Inject]
         private IToastService ToastService { get; set; }

--- a/Server/Components/Devices/DeviceCard.razor.cs
+++ b/Server/Components/Devices/DeviceCard.razor.cs
@@ -26,9 +26,8 @@ namespace Remotely.Server.Components.Devices
     {
         private readonly ConcurrentDictionary<string, double> _fileUploadProgressLookup = new();
         private ElementReference _card;
-        private Theme _theme;
         private Version _currentVersion = new();
-
+        private Theme _theme;
         [Parameter]
         public Device Device { get; set; }
 
@@ -41,12 +40,6 @@ namespace Remotely.Server.Components.Devices
 
         [Inject]
         private ICircuitConnection CircuitConnection { get; set; }
-
-        [Inject]
-        private IServiceHubSessionCache ServiceSessionCache { get; init; }
-
-        [Inject]
-        private IUpgradeService UpgradeService { get; init; }
 
         [Inject]
         private IDataService DataService { get; set; }
@@ -64,9 +57,15 @@ namespace Remotely.Server.Components.Devices
 
         [Inject]
         private IModalService ModalService { get; set; }
+
+        [Inject]
+        private IServiceHubSessionCache ServiceSessionCache { get; init; }
+
         [Inject]
         private IToastService ToastService { get; set; }
 
+        [Inject]
+        private IUpgradeService UpgradeService { get; init; }
         public void Dispose()
         {
             AppState.PropertyChanged -= AppState_PropertyChanged;
@@ -321,6 +320,19 @@ namespace Remotely.Server.Components.Devices
                 AppState.DevicesFrameFocusedDevice = null;
                 AppState.DevicesFrameFocusedCardState = DeviceCardState.Normal;
                 ParentFrame.Refresh();
+            }
+        }
+
+        private async Task WakeDevice()
+        {
+            var result = await CircuitConnection.WakeDevice(Device);
+            if (result.IsSuccess)
+            {
+                ToastService.ShowToast2("Wake command sent.", ToastType.Success);
+            }
+            else
+            {
+                ToastService.ShowToast2($"Wake command failed.  Reason: {result.Reason}", ToastType.Error);
             }
         }
     }

--- a/Server/Components/Devices/DeviceCard.razor.cs
+++ b/Server/Components/Devices/DeviceCard.razor.cs
@@ -329,7 +329,7 @@ namespace Remotely.Server.Components.Devices
             if (result.IsSuccess)
             {
                 ToastService.ShowToast2(
-                    $"Wake command sent to {result.Value} peer devices.", 
+                    $"Wake command sent to peer devices.", 
                     ToastType.Success);
             }
             else

--- a/Server/Components/Devices/DevicesFrame.razor
+++ b/Server/Components/Devices/DevicesFrame.razor
@@ -8,17 +8,20 @@
         <div>
             <div>
                 <div>Device Group</div>
-                <select class="form-control" style="width: 200px" @bind="_selectedGroupId">
-                    <option value="@_deviceGroupAll">All</option>
-                    <option value="@_deviceGroupNone">None</option>
-                    @foreach (var group in _deviceGroups)
-                    {
-                        <option @key="group.ID" value="@group.ID">@group.Name</option>
-                    }
-                </select>
-                <button class="btn btn-sm btn-secondary" title="Wake Devices" style="width: 40px; margin-left: 5px;" @onclick="WakeDevices">
-                    <span class="oi oi-eye"></span>
-                </button>
+                <div class="text-nowrap">
+                    <select class="form-control d-inline" style="width: 200px" @bind="_selectedGroupId">
+                        <option value="@_deviceGroupAll">All</option>
+                        <option value="@_deviceGroupNone">None</option>
+                        @foreach (var group in _deviceGroups)
+                        {
+                            <option @key="group.ID" value="@group.ID">@group.Name</option>
+                        }
+                    </select>
+                    <button class="btn btn-sm btn-secondary" title="Wake Devices in Group" style="width: 40px; margin-left: 5px;" @onclick="WakeDevices">
+                        <span class="oi oi-eye"></span>
+                    </button>
+
+                </div>
             </div>
 
             <div>

--- a/Server/Components/Devices/DevicesFrame.razor
+++ b/Server/Components/Devices/DevicesFrame.razor
@@ -16,6 +16,9 @@
                         <option @key="group.ID" value="@group.ID">@group.Name</option>
                     }
                 </select>
+                <button class="btn btn-sm btn-secondary" title="Wake Devices" style="width: 40px; margin-left: 5px;" @onclick="WakeDevices">
+                    <span class="oi oi-eye"></span>
+                </button>
             </div>
 
             <div>

--- a/Server/Components/Devices/DevicesFrame.razor
+++ b/Server/Components/Devices/DevicesFrame.razor
@@ -18,7 +18,7 @@
                         }
                     </select>
                     <button class="btn btn-sm btn-secondary" title="Wake Devices in Group" style="width: 40px; margin-left: 5px;" @onclick="WakeDevices">
-                        <span class="oi oi-eye"></span>
+                        <span class="oi oi-power-standby"></span>
                     </button>
 
                 </div>

--- a/Server/Components/Devices/DevicesFrame.razor
+++ b/Server/Components/Devices/DevicesFrame.razor
@@ -9,7 +9,7 @@
             <div>
                 <div>Device Group</div>
                 <div class="text-nowrap">
-                    <select class="form-control d-inline" style="width: 200px" @bind="_selectedGroupId">
+                    <select class="form-control d-inline" style="width: 150px" @bind="_selectedGroupId">
                         <option value="@_deviceGroupAll">All</option>
                         <option value="@_deviceGroupNone">None</option>
                         @foreach (var group in _deviceGroups)

--- a/Server/Components/Devices/DevicesFrame.razor.cs
+++ b/Server/Components/Devices/DevicesFrame.razor.cs
@@ -257,20 +257,6 @@ namespace Remotely.Server.Components.Devices
 
         }
 
-        private IEnumerable<Device> GetDevicesInSelectedGroup()
-        {
-            if (_selectedGroupId == _deviceGroupNone)
-            {
-                return _allDevices.Where(x => x.DeviceGroupID is null);
-            }
-
-            if (_selectedGroupId == _deviceGroupAll)
-            {
-                return _allDevices;
-            }
-
-            return _allDevices.Where(x => x.DeviceGroupID == _selectedGroupId);
-        }
 
         private string GetDisplayName(PropertyInfo propInfo)
         {
@@ -353,8 +339,21 @@ namespace Remotely.Server.Components.Devices
 
         private async Task WakeDevices()
         {
-            var devices = GetDevicesInSelectedGroup();
-            var result = await CircuitConnection.WakeDevices(devices.ToArray());
+            var offlineDevices = DataService
+               .GetDevicesForUser(Username)
+               .Where(x => !x.IsOnline);
+
+            if (_selectedGroupId == _deviceGroupNone)
+            {
+                offlineDevices = offlineDevices.Where(x => x.DeviceGroupID is null);
+            }
+
+            if (_selectedGroupId != _deviceGroupAll)
+            {
+                offlineDevices = offlineDevices.Where(x => x.DeviceGroupID == _selectedGroupId);
+            }
+
+            var result = await CircuitConnection.WakeDevices(offlineDevices.ToArray());
 
             if (result.IsSuccess)
             {

--- a/Server/Components/Devices/DevicesFrame.razor.cs
+++ b/Server/Components/Devices/DevicesFrame.razor.cs
@@ -358,7 +358,9 @@ namespace Remotely.Server.Components.Devices
 
             if (result.IsSuccess)
             {
-                ToastService.ShowToast2("Wake commands sent.", ToastType.Success);
+                ToastService.ShowToast2(
+                    $"Wake commands sent to {result.Value} peer devices.", 
+                    ToastType.Success);
             }
             else
             {

--- a/Server/Components/Devices/DevicesFrame.razor.cs
+++ b/Server/Components/Devices/DevicesFrame.razor.cs
@@ -358,7 +358,7 @@ namespace Remotely.Server.Components.Devices
             if (result.IsSuccess)
             {
                 ToastService.ShowToast2(
-                    $"Wake commands sent to {result.Value} peer devices.", 
+                    $"Wake commands sent to peer devices.", 
                     ToastType.Success);
             }
             else

--- a/Server/Components/Devices/DevicesFrame.razor.cs
+++ b/Server/Components/Devices/DevicesFrame.razor.cs
@@ -257,6 +257,21 @@ namespace Remotely.Server.Components.Devices
 
         }
 
+        private IEnumerable<Device> GetDevicesInSelectedGroup()
+        {
+            if (_selectedGroupId == _deviceGroupNone)
+            {
+                return _allDevices.Where(x => x.DeviceGroupID is null);
+            }
+
+            if (_selectedGroupId == _deviceGroupAll)
+            {
+                return _allDevices;
+            }
+
+            return _allDevices.Where(x => x.DeviceGroupID == _selectedGroupId);
+        }
+
         private string GetDisplayName(PropertyInfo propInfo)
         {
             return propInfo.GetCustomAttribute<DisplayAttribute>()?.Name ?? propInfo.Name;
@@ -333,6 +348,23 @@ namespace Remotely.Server.Components.Devices
             else
             {
                 _sortDirection = ListSortDirection.Ascending;
+            }
+        }
+
+        private async Task WakeDevices()
+        {
+            var devices = GetDevicesInSelectedGroup();
+            var result = await CircuitConnection.WakeDevices(devices.ToArray());
+
+            if (result.IsSuccess)
+            {
+                ToastService.ShowToast2("Wake commands sent.", ToastType.Success);
+            }
+            else
+            {
+                ToastService.ShowToast2(
+                    $"Failed to send wake commands.  Reason: {result.Reason}", 
+                    ToastType.Error);
             }
         }
     }

--- a/Server/Components/Scripts/RunScript.razor.cs
+++ b/Server/Components/Scripts/RunScript.razor.cs
@@ -43,7 +43,7 @@ namespace Remotely.Server.Components.Scripts
         private IToastService ToastService { get; set; }
 
         [Inject]
-        private IServiceHubSessionCache ServiceSessionCache { get; init; }
+        private IAgentHubSessionCache ServiceSessionCache { get; init; }
 
         [Inject]
         private ICircuitConnection CircuitConnection { get; set; }

--- a/Server/Data/AppDb.cs
+++ b/Server/Data/AppDb.cs
@@ -141,7 +141,8 @@ namespace Remotely.Server.Data
                 .Property(x => x.MacAddresses)
                 .HasConversion(
                     x => JsonSerializer.Serialize(x, jsonOptions),
-                    x => DeserializeStringArray(x, jsonOptions));
+                    x => DeserializeStringArray(x, jsonOptions),
+                    valueComparer: _stringArrayComparer);
 
             builder.Entity<DeviceGroup>()
                 .HasMany(x => x.Devices);

--- a/Server/Data/AppDb.cs
+++ b/Server/Data/AppDb.cs
@@ -46,6 +46,7 @@ namespace Remotely.Server.Data
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
+            var jsonOptions = JsonSerializerOptions.Default;
 
             base.OnModelCreating(builder);
 
@@ -102,8 +103,8 @@ namespace Remotely.Server.Data
             builder.Entity<RemotelyUser>()
                 .Property(x => x.UserOptions)
                 .HasConversion(
-                    x => JsonSerializer.Serialize(x, (JsonSerializerOptions)null),
-                    x => JsonSerializer.Deserialize<RemotelyUserOptions>(x, (JsonSerializerOptions)null));
+                    x => JsonSerializer.Serialize(x, jsonOptions),
+                    x => JsonSerializer.Deserialize<RemotelyUserOptions>(x, jsonOptions));
             builder.Entity<RemotelyUser>()
                 .HasMany(x => x.SavedScripts)
                 .WithOne(x => x.Creator);
@@ -117,8 +118,8 @@ namespace Remotely.Server.Data
             builder.Entity<Device>()
                 .Property(x => x.Drives)
                 .HasConversion(
-                    x => JsonSerializer.Serialize(x, (JsonSerializerOptions)null),
-                    x => JsonSerializer.Deserialize<List<Drive>>(x, (JsonSerializerOptions)null));
+                    x => JsonSerializer.Serialize(x, jsonOptions),
+                    x => TryDeserializeProperty<List<Drive>>(x, jsonOptions));
             builder.Entity<Device>()
                .Property(x => x.Drives)
                .Metadata.SetValueComparer(new ValueComparer<List<Drive>>(true));
@@ -136,6 +137,11 @@ namespace Remotely.Server.Data
             builder.Entity<Device>()
                 .HasMany(x => x.ScriptSchedules)
                 .WithMany(x => x.Devices);
+            builder.Entity<Device>()
+                .Property(x => x.MacAddresses)
+                .HasConversion(
+                    x => JsonSerializer.Serialize(x, jsonOptions),
+                    x => DeserializeStringArray(x, jsonOptions));
 
             builder.Entity<DeviceGroup>()
                 .HasMany(x => x.Devices);
@@ -153,16 +159,16 @@ namespace Remotely.Server.Data
             builder.Entity<ScriptResult>()
               .Property(x => x.ErrorOutput)
               .HasConversion(
-                  x => JsonSerializer.Serialize(x, (JsonSerializerOptions)null),
-                  x => JsonSerializer.Deserialize<string[]>(x, (JsonSerializerOptions)null))
+                  x => JsonSerializer.Serialize(x, jsonOptions),
+                  x => DeserializeStringArray(x, jsonOptions))
               .Metadata
               .SetValueComparer(_stringArrayComparer);
 
             builder.Entity<ScriptResult>()
               .Property(x => x.StandardOutput)
               .HasConversion(
-                  x => JsonSerializer.Serialize(x, (JsonSerializerOptions)null),
-                  x => JsonSerializer.Deserialize<string[]>(x, (JsonSerializerOptions)null))
+                  x => JsonSerializer.Serialize(x, jsonOptions),
+                  x => DeserializeStringArray(x, jsonOptions))
               .Metadata
               .SetValueComparer(_stringArrayComparer);
 
@@ -197,6 +203,39 @@ namespace Remotely.Server.Data
                 }
             }
 
+        }
+
+        private static string[] DeserializeStringArray(string value, JsonSerializerOptions jsonOptions)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    return Array.Empty<string>();
+                }
+                return JsonSerializer.Deserialize<string[]>(value, jsonOptions) ?? Array.Empty<string>();
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        private static T TryDeserializeProperty<T>(string value, JsonSerializerOptions jsonOptions)
+            where T: new()
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    return new();
+                }
+                return JsonSerializer.Deserialize<T>(value, jsonOptions) ?? new();
+            }
+            catch
+            {
+                return new();
+            }
         }
     }
 }

--- a/Server/Enums/ToastType.cs
+++ b/Server/Enums/ToastType.cs
@@ -1,0 +1,12 @@
+﻿namespace Remotely.Server.Enums
+{
+    public enum ToastType
+    {
+        Primary,
+        Secondary,
+        Success,
+        Info,
+        Warning,
+        Error
+    }
+}

--- a/Server/Hubs/AgentHub.cs
+++ b/Server/Hubs/AgentHub.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Remotely.Server.Models;
 using Remotely.Server.Services;
 using Remotely.Shared;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Enums;
 using Remotely.Shared.Models;
 using Remotely.Shared.Utilities;
@@ -87,11 +88,11 @@ namespace Remotely.Server.Hubs
             }
         }
 
-        public async Task<bool> DeviceCameOnline(Device device)
+        public async Task<bool> DeviceCameOnline(DeviceClientDto device)
         {
             try
             {
-                if (CheckForDeviceBan(device.ID, device.DeviceName))
+                if (CheckForDeviceBan(device.Id, device.DeviceName))
                 {
                     return false;
                 }
@@ -144,9 +145,9 @@ namespace Remotely.Server.Hubs
             return false;
         }
 
-        public async Task DeviceHeartbeat(Device device)
+        public async Task DeviceHeartbeat(DeviceClientDto device)
         {
-            if (CheckForDeviceBan(device.ID, device.DeviceName))
+            if (CheckForDeviceBan(device.Id, device.DeviceName))
             {
                 return;
             }

--- a/Server/Hubs/AgentHub.cs
+++ b/Server/Hubs/AgentHub.cs
@@ -24,12 +24,12 @@ namespace Remotely.Server.Hubs
         private readonly IDataService _dataService;
         private readonly IExpiringTokenService _expiringTokenService;
         private readonly ILogger<AgentHub> _logger;
-        private readonly IServiceHubSessionCache _serviceSessionCache;
+        private readonly IAgentHubSessionCache _serviceSessionCache;
         private readonly IHubContext<ViewerHub> _viewerHubContext;
 
         public AgentHub(IDataService dataService,
             IApplicationConfig appConfig,
-            IServiceHubSessionCache serviceSessionCache,
+            IAgentHubSessionCache serviceSessionCache,
             IHubContext<ViewerHub> viewerHubContext,
             ICircuitManager circuitManager,
             IExpiringTokenService expiringTokenService,

--- a/Server/Hubs/CircuitConnection.cs
+++ b/Server/Hubs/CircuitConnection.cs
@@ -600,7 +600,7 @@ namespace Remotely.Server.Hubs
         {
             foreach (var peerDevice in peerDevices)
             {
-                foreach (var mac in deviceToWake.MacAddresses)
+                foreach (var mac in deviceToWake.MacAddresses ?? Array.Empty<string>())
                 {
                     if (_serviceSessionCache.TryGetConnectionId(peerDevice.ID, out var connectionId))
                     {

--- a/Server/Migrations/PostgreSql/20230622144413_Add_Agent_MacAddress.Designer.cs
+++ b/Server/Migrations/PostgreSql/20230622144413_Add_Agent_MacAddress.Designer.cs
@@ -2,33 +2,36 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Remotely.Server.Data;
 
 #nullable disable
 
-namespace Remotely.Server.Migrations.SqlServer
+namespace Remotely.Server.Migrations.PostgreSql
 {
-    [DbContext(typeof(SqlServerDbContext))]
-    partial class SqlServerDbContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(PostgreSqlDbContext))]
+    [Migration("20230622144413_Add_Agent_MacAddress")]
+    partial class Add_Agent_MacAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "7.0.7")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("DeviceGroupRemotelyUser", b =>
                 {
                     b.Property<string>("DeviceGroupsID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UsersId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("DeviceGroupsID", "UsersId");
 
@@ -40,10 +43,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceGroupScriptSchedule", b =>
                 {
                     b.Property<string>("DeviceGroupsID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("ScriptSchedulesId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("DeviceGroupsID", "ScriptSchedulesId");
 
@@ -55,10 +58,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceScriptRun", b =>
                 {
                     b.Property<string>("DevicesID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("ScriptRunsId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("DevicesID", "ScriptRunsId");
 
@@ -70,10 +73,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceScriptRun1", b =>
                 {
                     b.Property<string>("DevicesCompletedID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("ScriptRunsCompletedId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("DevicesCompletedID", "ScriptRunsCompletedId");
 
@@ -85,10 +88,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceScriptSchedule", b =>
                 {
                     b.Property<string>("DevicesID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("ScriptSchedulesId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("DevicesID", "ScriptSchedulesId");
 
@@ -100,26 +103,25 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("NormalizedName")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedName")
                         .IsUnique()
-                        .HasDatabaseName("RoleNameIndex")
-                        .HasFilter("[NormalizedName] IS NOT NULL");
+                        .HasDatabaseName("RoleNameIndex");
 
                     b.ToTable("AspNetRoles", (string)null);
                 });
@@ -128,19 +130,19 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("RoleId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -152,58 +154,58 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("AccessFailedCount")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Discriminator")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<bool>("EmailConfirmed")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("LockoutEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTimeOffset?>("LockoutEnd")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("NormalizedEmail")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("NormalizedUserName")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("PasswordHash")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("PhoneNumberConfirmed")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SecurityStamp")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("TwoFactorEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("UserName")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.HasKey("Id");
 
@@ -212,8 +214,7 @@ namespace Remotely.Server.Migrations.SqlServer
 
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
-                        .HasDatabaseName("UserNameIndex")
-                        .HasFilter("[NormalizedUserName] IS NOT NULL");
+                        .HasDatabaseName("UserNameIndex");
 
                     b.ToTable("RemotelyUsers", (string)null);
 
@@ -226,19 +227,19 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -250,17 +251,17 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ProviderKey")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ProviderDisplayName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("LoginProvider", "ProviderKey");
 
@@ -272,10 +273,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
                 {
                     b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("RoleId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("UserId", "RoleId");
 
@@ -287,16 +288,16 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
                 {
                     b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Value")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("UserId", "LoginProvider", "Name");
 
@@ -307,25 +308,25 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("CreatedOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Message")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UserID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("ID");
 
@@ -342,20 +343,20 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("LastUsed")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Secret")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("ID");
 
@@ -368,52 +369,51 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<byte>("ButtonForegroundBlue")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("ButtonForegroundGreen")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("ButtonForegroundRed")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte[]>("Icon")
                         .IsRequired()
-                        .HasColumnType("varbinary(max)");
+                        .HasColumnType("bytea");
 
                     b.Property<string>("OrganizationId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Product")
                         .IsRequired()
                         .HasMaxLength(25)
-                        .HasColumnType("nvarchar(25)");
+                        .HasColumnType("character varying(25)");
 
                     b.Property<byte>("TitleBackgroundBlue")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("TitleBackgroundGreen")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("TitleBackgroundRed")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("TitleForegroundBlue")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("TitleForegroundGreen")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.Property<byte>("TitleForegroundRed")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("smallint");
 
                     b.HasKey("Id");
 
                     b.HasIndex("OrganizationId")
-                        .IsUnique()
-                        .HasFilter("[OrganizationId] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("BrandingInfos");
                 });
@@ -421,82 +421,82 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Remotely.Shared.Models.Device", b =>
                 {
                     b.Property<string>("ID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("AgentVersion")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Alias")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<double>("CpuUtilization")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.Property<string>("CurrentUser")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceGroupID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceName")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Drives")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Is64Bit")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsOnline")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTimeOffset>("LastOnline")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("MacAddresses")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Notes")
                         .HasMaxLength(5000)
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("character varying(5000)");
 
                     b.Property<int>("OSArchitecture")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("OSDescription")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Platform")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("ProcessorCount")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PublicIP")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ServerVerificationToken")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Tags")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<double>("TotalMemory")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.Property<double>("TotalStorage")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.Property<double>("UsedMemory")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.Property<double>("UsedStorage")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.HasKey("ID");
 
@@ -513,14 +513,14 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("ID");
 
@@ -533,22 +533,22 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("DateSent")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("InvitedUser")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsAdmin")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ResetUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("ID");
 
@@ -561,14 +561,14 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDefaultOrganization")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(25)
-                        .HasColumnType("nvarchar(25)");
+                        .HasColumnType("character varying(25)");
 
                     b.HasKey("ID");
 
@@ -579,44 +579,44 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("CreatorId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("FolderPath")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<bool>("GenerateAlertOnError")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsPublic")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsQuickScript")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("SendEmailOnError")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SendErrorEmailTo")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Shell")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -631,52 +631,52 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DeviceID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ErrorOutput")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("HadErrors")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("InputType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<TimeSpan>("RunTime")
-                        .HasColumnType("time");
+                        .HasColumnType("interval");
 
                     b.Property<Guid?>("SavedScriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int?>("ScheduleId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ScriptInput")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int?>("ScriptRunId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SenderConnectionID")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("SenderUserName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Shell")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("StandardOutput")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("TimeStamp")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("ID");
 
@@ -695,33 +695,33 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Initiator")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("InputType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("RunAt")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("RunOnNextConnect")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid?>("SavedScriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int?>("ScheduleId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("ScriptScheduleId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -736,39 +736,39 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CreatorId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Interval")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset?>("LastRun")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("NextRun")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("RunOnNextConnect")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid>("SavedScriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTimeOffset>("StartAt")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -783,22 +783,22 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContentType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<byte[]>("FileContents")
-                        .HasColumnType("varbinary(max)");
+                        .HasColumnType("bytea");
 
                     b.Property<string>("FileName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("ID");
 
@@ -812,19 +812,19 @@ namespace Remotely.Server.Migrations.SqlServer
                     b.HasBaseType("Microsoft.AspNetCore.Identity.IdentityUser");
 
                     b.Property<bool>("IsAdministrator")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsServerAdmin")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TempPassword")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UserOptions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasIndex("OrganizationID");
 

--- a/Server/Migrations/PostgreSql/20230622144413_Add_Agent_MacAddress.cs
+++ b/Server/Migrations/PostgreSql/20230622144413_Add_Agent_MacAddress.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Remotely.Server.Migrations.PostgreSql
+{
+    /// <inheritdoc />
+    public partial class Add_Agent_MacAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MacAddresses",
+                table: "Devices",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MacAddresses",
+                table: "Devices");
+        }
+    }
+}

--- a/Server/Migrations/PostgreSql/PostgreSqlDbContextModelSnapshot.cs
+++ b/Server/Migrations/PostgreSql/PostgreSqlDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace Remotely.Server.Migrations.PostgreSql
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.5")
+                .HasAnnotation("ProductVersion", "7.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -450,6 +450,9 @@ namespace Remotely.Server.Migrations.PostgreSql
 
                     b.Property<DateTimeOffset>("LastOnline")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("MacAddresses")
+                        .HasColumnType("text");
 
                     b.Property<string>("Notes")
                         .HasMaxLength(5000)

--- a/Server/Migrations/SqlServer/20230622144404_Add_Agent_MacAddress.Designer.cs
+++ b/Server/Migrations/SqlServer/20230622144404_Add_Agent_MacAddress.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Remotely.Server.Data;
 
@@ -11,9 +12,11 @@ using Remotely.Server.Data;
 namespace Remotely.Server.Migrations.SqlServer
 {
     [DbContext(typeof(SqlServerDbContext))]
-    partial class SqlServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230622144404_Add_Agent_MacAddress")]
+    partial class Add_Agent_MacAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Migrations/SqlServer/20230622144404_Add_Agent_MacAddress.cs
+++ b/Server/Migrations/SqlServer/20230622144404_Add_Agent_MacAddress.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Remotely.Server.Migrations.SqlServer
+{
+    /// <inheritdoc />
+    public partial class Add_Agent_MacAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MacAddresses",
+                table: "Devices",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MacAddresses",
+                table: "Devices");
+        }
+    }
+}

--- a/Server/Migrations/Sqlite/20230622144355_Add_Agent_MacAddress.Designer.cs
+++ b/Server/Migrations/Sqlite/20230622144355_Add_Agent_MacAddress.Designer.cs
@@ -2,33 +2,31 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Remotely.Server.Data;
 
 #nullable disable
 
-namespace Remotely.Server.Migrations.SqlServer
+namespace Remotely.Server.Migrations.Sqlite
 {
-    [DbContext(typeof(SqlServerDbContext))]
-    partial class SqlServerDbContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(SqliteDbContext))]
+    [Migration("20230622144355_Add_Agent_MacAddress")]
+    partial class Add_Agent_MacAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.7")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "7.0.7");
 
             modelBuilder.Entity("DeviceGroupRemotelyUser", b =>
                 {
                     b.Property<string>("DeviceGroupsID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UsersId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("DeviceGroupsID", "UsersId");
 
@@ -40,10 +38,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceGroupScriptSchedule", b =>
                 {
                     b.Property<string>("DeviceGroupsID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ScriptSchedulesId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("DeviceGroupsID", "ScriptSchedulesId");
 
@@ -55,10 +53,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceScriptRun", b =>
                 {
                     b.Property<string>("DevicesID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ScriptRunsId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("DevicesID", "ScriptRunsId");
 
@@ -70,10 +68,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceScriptRun1", b =>
                 {
                     b.Property<string>("DevicesCompletedID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ScriptRunsCompletedId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("DevicesCompletedID", "ScriptRunsCompletedId");
 
@@ -85,10 +83,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("DeviceScriptSchedule", b =>
                 {
                     b.Property<string>("DevicesID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ScriptSchedulesId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("DevicesID", "ScriptSchedulesId");
 
@@ -100,26 +98,25 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NormalizedName")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedName")
                         .IsUnique()
-                        .HasDatabaseName("RoleNameIndex")
-                        .HasFilter("[NormalizedName] IS NOT NULL");
+                        .HasDatabaseName("RoleNameIndex");
 
                     b.ToTable("AspNetRoles", (string)null);
                 });
@@ -128,19 +125,17 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RoleId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -152,58 +147,58 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("AccessFailedCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Discriminator")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("EmailConfirmed")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("LockoutEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
-                    b.Property<DateTimeOffset?>("LockoutEnd")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("LockoutEnd")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NormalizedEmail")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("NormalizedUserName")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PasswordHash")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("PhoneNumberConfirmed")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SecurityStamp")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("TwoFactorEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("UserName")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -212,8 +207,7 @@ namespace Remotely.Server.Migrations.SqlServer
 
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
-                        .HasDatabaseName("UserNameIndex")
-                        .HasFilter("[NormalizedUserName] IS NOT NULL");
+                        .HasDatabaseName("UserNameIndex");
 
                     b.ToTable("RemotelyUsers", (string)null);
 
@@ -226,19 +220,17 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -250,17 +242,17 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderKey")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProviderDisplayName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("LoginProvider", "ProviderKey");
 
@@ -272,10 +264,10 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
                 {
                     b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RoleId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("UserId", "RoleId");
 
@@ -287,16 +279,16 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
                 {
                     b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Value")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("UserId", "LoginProvider", "Name");
 
@@ -307,25 +299,26 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("CreatedOn")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("CreatedOn")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Message")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -342,20 +335,20 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset?>("LastUsed")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("LastUsed")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Secret")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -368,52 +361,51 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte>("ButtonForegroundBlue")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("ButtonForegroundGreen")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("ButtonForegroundRed")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte[]>("Icon")
                         .IsRequired()
-                        .HasColumnType("varbinary(max)");
+                        .HasColumnType("BLOB");
 
                     b.Property<string>("OrganizationId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Product")
                         .IsRequired()
                         .HasMaxLength(25)
-                        .HasColumnType("nvarchar(25)");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte>("TitleBackgroundBlue")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("TitleBackgroundGreen")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("TitleBackgroundRed")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("TitleForegroundBlue")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("TitleForegroundGreen")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("TitleForegroundRed")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
                     b.HasIndex("OrganizationId")
-                        .IsUnique()
-                        .HasFilter("[OrganizationId] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("BrandingInfos");
                 });
@@ -421,82 +413,83 @@ namespace Remotely.Server.Migrations.SqlServer
             modelBuilder.Entity("Remotely.Shared.Models.Device", b =>
                 {
                     b.Property<string>("ID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AgentVersion")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Alias")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<double>("CpuUtilization")
-                        .HasColumnType("float");
+                        .HasColumnType("REAL");
 
                     b.Property<string>("CurrentUser")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceGroupID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceName")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Drives")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("Is64Bit")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsOnline")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
-                    b.Property<DateTimeOffset>("LastOnline")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("LastOnline")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MacAddresses")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Notes")
                         .HasMaxLength(5000)
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("OSArchitecture")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OSDescription")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Platform")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ProcessorCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PublicIP")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ServerVerificationToken")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Tags")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<double>("TotalMemory")
-                        .HasColumnType("float");
+                        .HasColumnType("REAL");
 
                     b.Property<double>("TotalStorage")
-                        .HasColumnType("float");
+                        .HasColumnType("REAL");
 
                     b.Property<double>("UsedMemory")
-                        .HasColumnType("float");
+                        .HasColumnType("REAL");
 
                     b.Property<double>("UsedStorage")
-                        .HasColumnType("float");
+                        .HasColumnType("REAL");
 
                     b.HasKey("ID");
 
@@ -513,14 +506,14 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -533,22 +526,23 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("DateSent")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("DateSent")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InvitedUser")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsAdmin")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ResetUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -561,14 +555,14 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsDefaultOrganization")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OrganizationName")
                         .HasMaxLength(25)
-                        .HasColumnType("nvarchar(25)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -579,44 +573,44 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Content")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CreatorId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FolderPath")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("GenerateAlertOnError")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsPublic")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsQuickScript")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("SendEmailOnError")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SendErrorEmailTo")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Shell")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -631,52 +625,53 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DeviceID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ErrorOutput")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("HadErrors")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("InputType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<TimeSpan>("RunTime")
-                        .HasColumnType("time");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("SavedScriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ScheduleId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ScriptInput")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ScriptRunId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SenderConnectionID")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SenderUserName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Shell")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("StandardOutput")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("TimeStamp")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("TimeStamp")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -695,33 +690,32 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Initiator")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("InputType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("RunAt")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("RunAt")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("RunOnNextConnect")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid?>("SavedScriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ScheduleId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ScriptScheduleId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -736,39 +730,40 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("CreatedAt")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CreatorId")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Interval")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
-                    b.Property<DateTimeOffset?>("LastRun")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("LastRun")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("NextRun")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("NextRun")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("RunOnNextConnect")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<Guid>("SavedScriptId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("StartAt")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("StartAt")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -783,22 +778,23 @@ namespace Remotely.Server.Migrations.SqlServer
                 {
                     b.Property<string>("ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContentType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte[]>("FileContents")
-                        .HasColumnType("varbinary(max)");
+                        .HasColumnType("BLOB");
 
                     b.Property<string>("FileName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<string>("Timestamp")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ID");
 
@@ -812,19 +808,19 @@ namespace Remotely.Server.Migrations.SqlServer
                     b.HasBaseType("Microsoft.AspNetCore.Identity.IdentityUser");
 
                     b.Property<bool>("IsAdministrator")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsServerAdmin")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OrganizationID")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TempPassword")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("UserOptions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasIndex("OrganizationID");
 

--- a/Server/Migrations/Sqlite/20230622144355_Add_Agent_MacAddress.cs
+++ b/Server/Migrations/Sqlite/20230622144355_Add_Agent_MacAddress.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Remotely.Server.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    public partial class Add_Agent_MacAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MacAddresses",
+                table: "Devices",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MacAddresses",
+                table: "Devices");
+        }
+    }
+}

--- a/Server/Migrations/Sqlite/SqliteDbContextModelSnapshot.cs
+++ b/Server/Migrations/Sqlite/SqliteDbContextModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace Remotely.Server.Migrations.Sqlite
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "7.0.5");
+            modelBuilder.HasAnnotation("ProductVersion", "7.0.7");
 
             modelBuilder.Entity("DeviceGroupRemotelyUser", b =>
                 {
@@ -442,6 +442,9 @@ namespace Remotely.Server.Migrations.Sqlite
 
                     b.Property<string>("LastOnline")
                         .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("MacAddresses")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Notes")

--- a/Server/Pages/DeviceDetails.razor
+++ b/Server/Pages/DeviceDetails.razor
@@ -135,6 +135,22 @@ else
                             </div>
                         </div>
                         <div class="form-group row">
+                            <label for="agent-memory-total" class="col-sm-2 col-form-label">
+                                Public IP:
+                            </label>
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" name="agent-memory-total" readonly value="@(Device.PublicIP)" />
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="agent-memory-total" class="col-sm-2 col-form-label">
+                                MAC Addresses:
+                            </label>
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" name="agent-memory-total" readonly value="@(string.Join(", ", Device.MacAddresses))" />
+                            </div>
+                        </div>
+                        <div class="form-group row">
                             <label for="device-alias" class="col-sm-2 col-form-label">Device Alias:</label>
                             <div class="col-sm-10">
                                 <InputText class="form-control" @bind-Value="@Device.Alias" />
@@ -148,9 +164,9 @@ else
                                     <option value="">None</option>
 
                                     @foreach (var group in DataService.GetDeviceGroups(Username))
-                                        {
+                                    {
                                         <option @key="group.ID" value="@group.ID">@group.Name</option>
-                                        }
+                                    }
                                 </InputSelect>
                                 <ValidationMessage For="() => Device.DeviceGroupID" />
                             </div>

--- a/Server/Pages/DeviceDetails.razor
+++ b/Server/Pages/DeviceDetails.razor
@@ -147,7 +147,12 @@ else
                                 MAC Addresses:
                             </label>
                             <div class="col-sm-10">
-                                <input type="text" class="form-control" name="agent-memory-total" readonly value="@(string.Join(", ", Device.MacAddresses))" />
+                                <input 
+                                    type="text" 
+                                    class="form-control" 
+                                    name="agent-memory-total" 
+                                    readonly
+                                       value="@(string.Join(", ", Device.MacAddresses ?? Array.Empty<string>()))" />
                             </div>
                         </div>
                         <div class="form-group row">

--- a/Server/Pages/ServerConfig.razor.cs
+++ b/Server/Pages/ServerConfig.razor.cs
@@ -162,7 +162,7 @@ namespace Remotely.Server.Pages
         private ILogger<ServerConfig> Logger { get; set; }
 
         [Inject]
-        private IServiceHubSessionCache ServiceSessionCache { get; init; }
+        private IAgentHubSessionCache ServiceSessionCache { get; init; }
 
         private AppSettingsModel Input { get; } = new();
 

--- a/Server/Pages/ServerLogs.razor
+++ b/Server/Pages/ServerLogs.razor
@@ -69,7 +69,7 @@
     private LogLevel? _logLevel;
     private string _messageFilter = string.Empty;
 
-    private DateTimeOffset _fromDate = DateTimeOffset.Now.AddDays(-7);
+    private DateTimeOffset _fromDate = DateTimeOffset.Now.AddDays(-1);
     private DateTimeOffset _toDate = DateTimeOffset.Now;
 
     private DateTimeOffset FromDate

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -219,7 +219,7 @@ services.AddScoped<IScriptScheduleDispatcher, ScriptScheduleDispatcher>();
 services.AddSingleton<IOtpProvider, OtpProvider>();
 services.AddSingleton<IEmbeddedServerDataSearcher, EmbeddedServerDataSearcher>();
 services.AddSingleton<ILogsManager, LogsManager>();
-services.AddSingleton(WeakReferenceMessenger.Default);
+services.AddScoped<IMessenger>((services) => new WeakReferenceMessenger());
 
 services.AddRemoteControlServer(config =>
 {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -228,7 +228,7 @@ services.AddRemoteControlServer(config =>
     config.AddViewerPageDataProvider<ViewerPageDataProvider>();
 });
 
-services.AddSingleton<IServiceHubSessionCache, ServiceHubSessionCache>();
+services.AddSingleton<IAgentHubSessionCache, AgentHubSessionCache>();
 
 var app = builder.Build();
 var appConfig = app.Services.GetRequiredService<IApplicationConfig>();

--- a/Server/Properties/AssemblyInfo.cs
+++ b/Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Remotely.Server.Tests")]

--- a/Server/Services/AgentHubSessionCache.cs
+++ b/Server/Services/AgentHubSessionCache.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Remotely.Server.Services
 {
-    public interface IServiceHubSessionCache
+    public interface IAgentHubSessionCache
     {
         void AddOrUpdateByConnectionId(string connectionId, Device device);
         ICollection<Device> GetAllDevices();
@@ -16,7 +16,7 @@ namespace Remotely.Server.Services
         bool TryRemoveByConnectionId(string connectionId, out Device device);
     }
 
-    public class ServiceHubSessionCache : IServiceHubSessionCache
+    public class AgentHubSessionCache : IAgentHubSessionCache
     {
 
         private readonly ConcurrentDictionary<string, Device> _connectionIdToDeviceLookup = new();

--- a/Server/Services/DataService.cs
+++ b/Server/Services/DataService.cs
@@ -347,7 +347,7 @@ namespace Remotely.Server.Services
                 resultDevice.TotalMemory = device.TotalMemory;
                 resultDevice.TotalStorage = device.TotalStorage;
                 resultDevice.AgentVersion = device.AgentVersion;
-                resultDevice.MacAddresses = device.MacAddresses;
+                resultDevice.MacAddresses = device.MacAddresses ?? Array.Empty<string>();
                 resultDevice.LastOnline = DateTimeOffset.Now;
             }
             else

--- a/Server/Services/DataService.cs
+++ b/Server/Services/DataService.cs
@@ -328,6 +328,7 @@ namespace Remotely.Server.Services
             using var dbContext = _appDbFactory.GetContext();
 
             var resultDevice = await dbContext.Devices.FindAsync(device.ID);
+
             if (resultDevice != null)
             {
                 resultDevice.CurrentUser = device.CurrentUser;
@@ -346,6 +347,7 @@ namespace Remotely.Server.Services
                 resultDevice.TotalMemory = device.TotalMemory;
                 resultDevice.TotalStorage = device.TotalStorage;
                 resultDevice.AgentVersion = device.AgentVersion;
+                resultDevice.MacAddresses = device.MacAddresses;
                 resultDevice.LastOnline = DateTimeOffset.Now;
             }
             else

--- a/Server/Services/ScriptScheduleDispatcher.cs
+++ b/Server/Services/ScriptScheduleDispatcher.cs
@@ -19,12 +19,12 @@ namespace Remotely.Server.Services
     public class ScriptScheduleDispatcher : IScriptScheduleDispatcher
     {
         private readonly IDataService _dataService;
-        private readonly IServiceHubSessionCache _serviceSessionCache;
+        private readonly IAgentHubSessionCache _serviceSessionCache;
         private readonly ICircuitConnection _circuitConnection;
         private readonly ILogger<ScriptScheduleDispatcher> _logger;
 
         public ScriptScheduleDispatcher(IDataService dataService,
-            IServiceHubSessionCache serviceSessionCache,
+            IAgentHubSessionCache serviceSessionCache,
             ICircuitConnection circuitConnection,
             ILogger<ScriptScheduleDispatcher> logger)
         {

--- a/Server/Services/ScriptScheduler.cs
+++ b/Server/Services/ScriptScheduler.cs
@@ -61,9 +61,7 @@ namespace Remotely.Server.Services
         {
             using var scope = _serviceProvider.CreateScope();
             var scriptScheduleDispatcher = scope.ServiceProvider.GetRequiredService<IScriptScheduleDispatcher>();
-            var dataService = scope.ServiceProvider.GetRequiredService<IDataService>();
             var logger = scope.ServiceProvider.GetRequiredService<ILogger<ScriptScheduler>>();
-            var circuitConnection = scope.ServiceProvider.GetRequiredService<ICircuitConnection>();
 
             try
             {

--- a/Server/Services/ToastService.cs
+++ b/Server/Services/ToastService.cs
@@ -1,4 +1,5 @@
 ﻿using Nihs.ConcurrentList;
+using Remotely.Server.Enums;
 using Remotely.Server.Models;
 using System;
 using System.Timers;
@@ -7,11 +8,20 @@ namespace Remotely.Server.Services
 {
     public interface IToastService
     {
-        ConcurrentList<Toast> Toasts { get; }
-
         event EventHandler OnToastsChanged;
 
-        void ShowToast(string message, int expirationMillisecond = 3000, string classString = null, string styleOverrides = null);
+        ConcurrentList<Toast> Toasts { get; }
+        void ShowToast(
+            string message, 
+            int expirationMillisecond = 3000, 
+            string classString = null, 
+            string styleOverrides = null);
+
+        void ShowToast2(
+            string message,
+             ToastType toastType = ToastType.Info,
+            int expirationMillisecond = 3000,
+            string styleOverrides = null);
     }
 
     public class ToastService : IToastService
@@ -51,6 +61,24 @@ namespace Remotely.Server.Services
                 removeToastTimer.Dispose();
             };
             removeToastTimer.Start();
+        }
+
+        public void ShowToast2(
+            string message, 
+            ToastType toastType,
+            int expirationMillisecond = 3000, 
+            string styleOverrides = null)
+        {
+            var classString = toastType switch
+            {
+                ToastType.Info => "bg-info text-white",
+                ToastType.Success => "bg-success text-white",
+                ToastType.Warning => "bg-warning text-white",
+                ToastType.Error => "bg-danger text-white",
+                _ => "bg-info text-white"
+            };
+
+            ShowToast(message, expirationMillisecond, classString, styleOverrides);
         }
     }
 }

--- a/Shared/Dtos/DeviceClientDto.cs
+++ b/Shared/Dtos/DeviceClientDto.cs
@@ -1,0 +1,73 @@
+﻿using Remotely.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Remotely.Shared.Dtos
+{
+    [DataContract]
+    public class DeviceClientDto
+    {
+        [DataMember]
+        public string AgentVersion { get; set; } = string.Empty;
+
+        [DataMember]
+        public double CpuUtilization { get; set; }
+
+        [DataMember]
+        public string CurrentUser { get; set; } = string.Empty;
+
+        [DataMember]
+        public string DeviceName { get; set; } = string.Empty;
+
+        [DataMember]
+        public List<Drive> Drives { get; set; } = new();
+
+        [DataMember]
+        public string Id { get; set; } = string.Empty;
+
+        [DataMember]
+        public bool Is64Bit { get; set; }
+
+        [DataMember]
+        public bool IsOnline { get; set; }
+
+        [DataMember]
+        public string[] MacAddresses { get; set; } = Array.Empty<string>();
+
+        [DataMember]
+        public string OrganizationId { get; set; } = string.Empty;
+
+        [DataMember]
+        public Architecture OsArchitecture { get; set; }
+
+        [DataMember]
+        public string OsDescription { get; set; } = string.Empty;
+
+        [DataMember]
+        public string Platform { get; set; } = string.Empty;
+
+        [DataMember]
+        public int ProcessorCount { get; set; }
+
+        [DataMember]
+        public string PublicIP { get; set; } = string.Empty;
+
+        [DataMember]
+        public double TotalMemory { get; set; }
+
+        [DataMember]
+        public double TotalStorage { get; set; }
+
+        [DataMember]
+        public double UsedMemory { get; set; }
+
+        [DataMember]
+        public double UsedStorage { get; set; }
+    }
+}

--- a/Shared/Extensions/DeviceExtensions.cs
+++ b/Shared/Extensions/DeviceExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Remotely.Shared.Dtos;
+using Remotely.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Remotely.Shared.Extensions
+{
+    public static class DeviceExtensions
+    {
+        private static JsonSerializerOptions _serializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        /// <summary>
+        /// A helper method for creating a DeviceClientDto from a Device entity.
+        /// </summary>
+        /// <param name="device"></param>
+        /// <returns></returns>
+        public static DeviceClientDto ToDto(this Device device)
+        {
+            var json = JsonSerializer.Serialize(device, _serializerOptions);
+            return JsonSerializer.Deserialize<DeviceClientDto>(json, _serializerOptions);
+        }
+    }
+}

--- a/Shared/Models/Device.cs
+++ b/Shared/Models/Device.cs
@@ -49,6 +49,10 @@ namespace Remotely.Shared.Models
         [Display(Name = "Last Online")]
         public DateTimeOffset LastOnline { get; set; }
 
+        [Sortable]
+        [Display(Name = "MAC Addresses")]
+        public string[] MacAddresses { get; set; } = Array.Empty<string>();
+
         [StringLength(5000)]
         public string Notes { get; set; }       
 
@@ -71,19 +75,19 @@ namespace Remotely.Shared.Models
         public int ProcessorCount { get; set; }
 
         public string PublicIP { get; set; }
-        public string ServerVerificationToken { get; set; }
-
         [JsonIgnore]
         public List<ScriptResult> ScriptResults { get; set; }
 
         [JsonIgnore]
         public List<ScriptRun> ScriptRuns { get; set; }
+
         [JsonIgnore]
         public List<ScriptRun> ScriptRunsCompleted { get; set; }
 
         [JsonIgnore]
         public List<ScriptSchedule> ScriptSchedules { get; set; }
 
+        public string ServerVerificationToken { get; set; }
         [StringLength(200)]
         [Sortable]
         [Display(Name = "Tags")]

--- a/Shared/Models/Device.cs
+++ b/Shared/Models/Device.cs
@@ -3,6 +3,7 @@ using Remotely.Shared.Enums;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 
@@ -107,7 +108,17 @@ namespace Remotely.Shared.Models
 
         [Sortable]
         [Display(Name = "Memory Used %")]
-        public double UsedMemoryPercent => UsedMemory / TotalMemory;
+        public double UsedMemoryPercent
+        {
+            get
+            {
+                if (TotalMemory == 0)
+                {
+                    return 0;
+                }
+                return UsedMemory / TotalMemory;
+            }
+        }
 
         [Sortable]
         [Display(Name = "Storage Used")]
@@ -115,6 +126,16 @@ namespace Remotely.Shared.Models
 
         [Sortable]
         [Display(Name = "Storage Used %")]
-        public double UsedStoragePercent => UsedStorage / TotalStorage;
+        public double UsedStoragePercent
+        {
+            get
+            {
+                if (TotalStorage == 0)
+                {
+                    return 0;
+                }
+                return UsedStorage / TotalStorage;
+            }
+        }
     }
 }

--- a/Tests/LoadTester/Program.cs
+++ b/Tests/LoadTester/Program.cs
@@ -116,7 +116,7 @@ internal class Program
                     {
                         try
                         {
-                            var currentInfo = await _deviceInfo.CreateDevice(device.ID, _organizationId);
+                            var currentInfo = await _deviceInfo.CreateDevice(device.Id, _organizationId);
                             currentInfo.DeviceName = device.DeviceName;
                             await hubConnection.SendAsync("DeviceHeartbeat", currentInfo);
                         }

--- a/Tests/Server.Tests/AgentHubTests.cs
+++ b/Tests/Server.Tests/AgentHubTests.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Server.Abstractions;
+﻿using Remotely.Shared.Extensions;
 using Immense.RemoteControl.Server.Hubs;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR;
@@ -9,6 +9,7 @@ using Moq;
 using Remotely.Server.Hubs;
 using Remotely.Server.Models;
 using Remotely.Server.Services;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Models;
 using System;
 using System.Collections.Generic;
@@ -57,7 +58,7 @@ namespace Remotely.Tests
             hubClients.Setup(x => x.Caller).Returns(caller.Object);
             hub.Clients = hubClients.Object;
 
-            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1));
+            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1.ToDto()));
             hubClients.Verify(x => x.Caller, Times.Once);
             caller.Verify(x => x.SendCoreAsync("UninstallAgent", It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -94,7 +95,7 @@ namespace Remotely.Tests
             hubClients.Setup(x => x.Caller).Returns(caller.Object);
             hub.Clients = hubClients.Object;
 
-            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1));
+            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1.ToDto()));
             hubClients.Verify(x => x.Caller, Times.Once);
             caller.Verify(x => x.SendCoreAsync("UninstallAgent", It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
         }

--- a/Tests/Server.Tests/AgentHubTests.cs
+++ b/Tests/Server.Tests/AgentHubTests.cs
@@ -34,14 +34,14 @@ namespace Remotely.Tests
             var circuitManager = new Mock<ICircuitManager>();
             var circuitConnection = new Mock<ICircuitConnection>();
             circuitManager.Setup(x => x.Connections).Returns(new[] { circuitConnection.Object });
-            circuitConnection.Setup(x => x.User).Returns(_testData.Admin1);
+            circuitConnection.Setup(x => x.User).Returns(_testData.Org1Admin1);
             var appConfig = new Mock<IApplicationConfig>();
             var viewerHub = new Mock<IHubContext<ViewerHub>>();
             var expiringTokenService = new Mock<IExpiringTokenService>();
-            var serviceSessionCache = new Mock<IServiceHubSessionCache>();
+            var serviceSessionCache = new Mock<IAgentHubSessionCache>();
             var logger = new Mock<ILogger<AgentHub>>();
 
-            appConfig.Setup(x => x.BannedDevices).Returns(new string[] { _testData.Device1.DeviceName });
+            appConfig.Setup(x => x.BannedDevices).Returns(new string[] { _testData.Org1Device1.DeviceName });
 
             var hub = new AgentHub(
                 DataService, 
@@ -57,7 +57,7 @@ namespace Remotely.Tests
             hubClients.Setup(x => x.Caller).Returns(caller.Object);
             hub.Clients = hubClients.Object;
 
-            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Device1));
+            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1));
             hubClients.Verify(x => x.Caller, Times.Once);
             caller.Verify(x => x.SendCoreAsync("UninstallAgent", It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -71,14 +71,14 @@ namespace Remotely.Tests
             var circuitManager = new Mock<ICircuitManager>();
             var circuitConnection = new Mock<ICircuitConnection>();
             circuitManager.Setup(x => x.Connections).Returns(new[] { circuitConnection.Object });
-            circuitConnection.Setup(x => x.User).Returns(_testData.Admin1);
+            circuitConnection.Setup(x => x.User).Returns(_testData.Org1Admin1);
             var appConfig = new Mock<IApplicationConfig>();
             var viewerHub = new Mock<IHubContext<ViewerHub>>();
             var expiringTokenService = new Mock<IExpiringTokenService>();
-            var serviceSessionCache = new Mock<IServiceHubSessionCache>();
+            var serviceSessionCache = new Mock<IAgentHubSessionCache>();
             var logger = new Mock<ILogger<AgentHub>>();
 
-            appConfig.Setup(x => x.BannedDevices).Returns(new string[] { _testData.Device1.ID });
+            appConfig.Setup(x => x.BannedDevices).Returns(new string[] { _testData.Org1Device1.ID });
 
             var hub = new AgentHub(
                 DataService,
@@ -94,7 +94,7 @@ namespace Remotely.Tests
             hubClients.Setup(x => x.Caller).Returns(caller.Object);
             hub.Clients = hubClients.Object;
 
-            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Device1));
+            Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1));
             hubClients.Verify(x => x.Caller, Times.Once);
             caller.Verify(x => x.SendCoreAsync("UninstallAgent", It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -106,9 +106,10 @@ namespace Remotely.Tests
         }
 
         [TestInitialize]
-        public void TestInit()
+        public async Task TestInit()
         {
             _testData = new TestData();
+            await _testData.Init();
             DataService = IoCActivator.ServiceProvider.GetRequiredService<IDataService>();
         }
 

--- a/Tests/Server.Tests/CircuitConnectionTests.cs
+++ b/Tests/Server.Tests/CircuitConnectionTests.cs
@@ -1,0 +1,442 @@
+﻿#nullable enable
+using Castle.Core.Logging;
+using Immense.RemoteControl.Server.Services;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Remotely.Server.Hubs;
+using Remotely.Server.Services;
+using Remotely.Server.Tests.Mocks;
+using Remotely.Shared.Models;
+using Remotely.Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Remotely.Server.Tests
+{
+    [TestClass]
+    public class CircuitConnectionTests
+    {
+#nullable disable
+        private TestData _testData;
+        private IDataService _dataService;
+        private Mock<IAuthService> _authService;
+        private Mock<IClientAppState> _clientAppState;
+        private HubContextFixture<AgentHub> _agentHubContextFixture;
+        private Mock<IApplicationConfig> _appConfig;
+        private Mock<ICircuitManager> _circuitManager;
+        private Mock<IToastService> _toastService;
+        private Mock<IExpiringTokenService> _expiringTokenService;
+        private Mock<IDesktopHubSessionCache> _desktopSessionCache;
+        private Mock<IAgentHubSessionCache> _agentSessionCache;
+        private Mock<ILogger<CircuitConnection>> _logger;
+        private CircuitConnection _circuitConnection;
+#nullable enable
+
+        [TestInitialize]
+        public async Task Init()
+        {
+            _testData = new TestData();
+            await _testData.Init();
+
+            _dataService = IoCActivator.ServiceProvider.GetRequiredService<IDataService>();
+            _authService = new Mock<IAuthService>();
+            _clientAppState = new Mock<IClientAppState>();
+            _agentHubContextFixture = new HubContextFixture<AgentHub>();
+            _appConfig = new Mock<IApplicationConfig>();
+            _circuitManager = new Mock<ICircuitManager>();
+            _toastService = new Mock<IToastService>();
+            _expiringTokenService = new Mock<IExpiringTokenService>();
+            _desktopSessionCache = new Mock<IDesktopHubSessionCache>();
+            _agentSessionCache = new Mock<IAgentHubSessionCache>();
+            _logger = new Mock<ILogger<CircuitConnection>>();
+
+            _circuitConnection = new CircuitConnection(
+                _authService.Object,
+                _dataService,
+                _clientAppState.Object,
+                _agentHubContextFixture.HubContextMock.Object,
+                _appConfig.Object,
+                _circuitManager.Object,
+                _toastService.Object,
+                _expiringTokenService.Object,
+                _desktopSessionCache.Object,
+                _agentSessionCache.Object,
+                _logger.Object);
+        }
+
+        [TestMethod]
+        public async Task WakeDevice_GivenUserIsUnauthorized_Fails()
+        {
+            // A standard user won't have access if they aren't in the same
+            // group as the device.
+            _circuitConnection.User = _testData.Org1User1;
+
+            // Offline device.
+            _testData.Org1Device1.PublicIP = "142.251.33.110";
+            _testData.Org1Device1.MacAddresses = new[] { "78E3B5A1E45B" };
+            _testData.Org1Device1.DeviceGroupID = _testData.Org1Group1.ID;
+            // Online device.
+            _testData.Org1Device2.PublicIP = "142.251.33.110";
+            // Device in another org that shouldn't receive the command.
+            _testData.Org2Device1.PublicIP = "142.251.33.110";
+
+
+            var updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device2);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org2Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+
+            var wakeResult = await _circuitConnection.WakeDevice(_testData.Org1Device1);
+            Assert.IsFalse(wakeResult.IsSuccess);
+
+            _agentSessionCache.VerifyNoOtherCalls();
+            _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task WakeDevice_GivenMatchingPeerByIp_UsesCorrectPeer()
+        {
+            _circuitConnection.User = _testData.Org1User1;
+
+            var macAddress = "78E3B5A1E45B";
+
+            // Offline device.
+            _testData.Org1Device1.PublicIP = "142.251.33.110";
+            _testData.Org1Device1.MacAddresses = new[] { macAddress };
+            _testData.Org1Device1.DeviceGroupID = _testData.Org1Group1.ID;
+            // Online device.
+            _testData.Org1Device2.PublicIP = "142.251.33.110";
+            // Device in another org that shouldn't receive the command.
+            _testData.Org2Device1.PublicIP = "142.251.33.110";
+
+            var addToGroupResult = _dataService.AddUserToDeviceGroup(
+                _testData.Org1Id,
+                _testData.Org1Group1.ID,
+                _testData.Org1User1.UserName,
+                out _);
+
+            var updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device2);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org2Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+
+            _agentSessionCache
+                .Setup(x => x.GetAllDevices())
+                .Returns(new[] 
+                { 
+                    _testData.Org1Device2,
+                    _testData.Org2Device1
+                });
+
+            var connectionId = "HQUSIBxiOwNokVH_mYgGyg";
+
+            _agentSessionCache
+                .Setup(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId))
+                .Returns(true);
+
+            var wakeResult = await _circuitConnection.WakeDevice(_testData.Org1Device1);
+
+            Assert.IsTrue(addToGroupResult);
+            Assert.IsTrue(wakeResult.IsSuccess);
+
+
+            _agentSessionCache
+                .Verify(x => x.GetAllDevices(), Times.Once);
+
+            _agentSessionCache
+                .Verify(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId), Times.Once);
+
+            _agentHubContextFixture.HubClientsMock
+                .Verify(x => x.Client(connectionId), Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock
+                .Verify(x =>
+                    x.SendCoreAsync(
+                        "WakeDevice", 
+                        new object[] { macAddress },
+                        default), 
+                        Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
+            _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
+            _agentSessionCache.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task WakeDevice_GivenMatchingPeerByGroupId_UsesCorrectPeer()
+        {
+            _circuitConnection.User = _testData.Org1User1;
+
+            var macAddress = "78E3B5A1E45B";
+
+            // Offline device.
+            _testData.Org1Device1.PublicIP = "142.251.33.110";
+            _testData.Org1Device1.MacAddresses = new[] { macAddress };
+            _testData.Org1Device1.DeviceGroupID = _testData.Org1Group1.ID;
+            // Online device.
+            _testData.Org1Device2.DeviceGroupID = _testData.Org1Group1.ID;
+            // Device in another org that shouldn't receive the command.
+            _testData.Org2Device1.DeviceGroupID = _testData.Org2Group1.ID;
+
+            var addToGroupResult = _dataService.AddUserToDeviceGroup(
+                _testData.Org1Id,
+                _testData.Org1Group1.ID,
+                _testData.Org1User1.UserName,
+                out _);
+
+            var updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device2);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org2Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+
+            _agentSessionCache
+                .Setup(x => x.GetAllDevices())
+                .Returns(new[]
+                {
+                    _testData.Org1Device2,
+                    _testData.Org2Device1
+                });
+
+            var connectionId = "HQUSIBxiOwNokVH_mYgGyg";
+
+            _agentSessionCache
+                .Setup(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId))
+                .Returns(true);
+
+            var wakeResult = await _circuitConnection.WakeDevice(_testData.Org1Device1);
+
+            Assert.IsTrue(addToGroupResult);
+            Assert.IsTrue(wakeResult.IsSuccess);
+
+
+            _agentSessionCache
+                .Verify(x => x.GetAllDevices(), Times.Once);
+
+            _agentSessionCache
+                .Verify(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId), Times.Once);
+
+            _agentHubContextFixture.HubClientsMock
+                .Verify(x => x.Client(connectionId), Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock
+                .Verify(x =>
+                    x.SendCoreAsync(
+                        "WakeDevice",
+                        new object[] { macAddress },
+                        default),
+                        Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
+            _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
+            _agentSessionCache.VerifyNoOtherCalls();
+        }
+
+
+        [TestMethod]
+        public async Task WakeDevice_GivenNoMatchingGroupOrIp_DoesNotSend()
+        {
+            _circuitConnection.User = _testData.Org1User1;
+
+            var macAddress = "78E3B5A1E45B";
+
+            // Offline device.
+            _testData.Org1Device1.PublicIP = "142.251.33.110";
+            _testData.Org1Device1.MacAddresses = new[] { macAddress };
+            _testData.Org1Device1.DeviceGroupID = _testData.Org1Group1.ID;
+            // Online device, but in a different group.
+            _testData.Org1Device2.DeviceGroupID = _testData.Org1Group2.ID;
+            // Device in another org that shouldn't receive the command.
+            _testData.Org2Device1.DeviceGroupID = _testData.Org2Group1.ID;
+
+            var addToGroupResult = _dataService.AddUserToDeviceGroup(
+                _testData.Org1Id,
+                _testData.Org1Group1.ID,
+                _testData.Org1User1.UserName,
+                out _);
+
+            var updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device2);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org2Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+
+            _agentSessionCache
+                .Setup(x => x.GetAllDevices())
+                .Returns(new[]
+                {
+                    _testData.Org1Device2,
+                    _testData.Org2Device1
+                });
+
+            var wakeResult = await _circuitConnection.WakeDevice(_testData.Org1Device1);
+
+            Assert.IsTrue(addToGroupResult);
+            Assert.IsTrue(wakeResult.IsSuccess);
+
+
+            _agentSessionCache
+                .Verify(x => x.GetAllDevices(), Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
+            _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
+            _agentSessionCache.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task WakeDevices_GivenPeerIpMatches_UsesCorrectPeer()
+        {
+            _circuitConnection.User = _testData.Org1User1;
+
+            var macAddress = "78E3B5A1E45B";
+
+            // Offline device.
+            _testData.Org1Device1.PublicIP = "142.251.33.110";
+            _testData.Org1Device1.MacAddresses = new[] { macAddress };
+            _testData.Org1Device1.DeviceGroupID = _testData.Org1Group1.ID;
+            // Online device.
+            _testData.Org1Device2.PublicIP = "142.251.33.110";
+            // Device in another org that shouldn't receive the command.
+            _testData.Org2Device1.PublicIP = "142.251.33.110";
+
+            var addToGroupResult = _dataService.AddUserToDeviceGroup(
+                _testData.Org1Id,
+                _testData.Org1Group1.ID,
+                _testData.Org1User1.UserName,
+                out _);
+
+            var updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device2);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org2Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+
+            _agentSessionCache
+                .Setup(x => x.GetAllDevices())
+                .Returns(new[]
+                {
+                    _testData.Org1Device2,
+                    _testData.Org2Device1
+                });
+
+            var connectionId = "HQUSIBxiOwNokVH_mYgGyg";
+
+            _agentSessionCache
+                .Setup(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId))
+                .Returns(true);
+
+            var wakeResult = await _circuitConnection.WakeDevices(new[] { _testData.Org1Device1 });
+
+            Assert.IsTrue(addToGroupResult);
+            Assert.IsTrue(wakeResult.IsSuccess);
+
+
+            _agentSessionCache
+                .Verify(x => x.GetAllDevices(), Times.Once);
+
+            _agentSessionCache
+                .Verify(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId), Times.Once);
+
+            _agentHubContextFixture.HubClientsMock
+                .Verify(x => x.Client(connectionId), Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock
+                .Verify(x =>
+                    x.SendCoreAsync(
+                        "WakeDevice",
+                        new object[] { macAddress },
+                        default),
+                        Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
+            _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
+            _agentSessionCache.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task WakeDevices_GivenMatchingPeerByGroupId_UsesCorrectPeer()
+        {
+            _circuitConnection.User = _testData.Org1User1;
+
+            var macAddress = "78E3B5A1E45B";
+
+            // Offline device.
+            _testData.Org1Device1.PublicIP = "142.251.33.110";
+            _testData.Org1Device1.MacAddresses = new[] { macAddress };
+            _testData.Org1Device1.DeviceGroupID = _testData.Org1Group1.ID;
+            // Online device.
+            _testData.Org1Device2.DeviceGroupID = _testData.Org1Group1.ID;
+            // Device in another org that shouldn't receive the command.
+            _testData.Org2Device1.DeviceGroupID = _testData.Org2Group1.ID;
+
+            var addToGroupResult = _dataService.AddUserToDeviceGroup(
+                _testData.Org1Id,
+                _testData.Org1Group1.ID,
+                _testData.Org1User1.UserName,
+                out _);
+
+            var updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org1Device2);
+            Assert.IsTrue(updateResult.IsSuccess);
+            updateResult = await _dataService.AddOrUpdateDevice(_testData.Org2Device1);
+            Assert.IsTrue(updateResult.IsSuccess);
+
+            _agentSessionCache
+                .Setup(x => x.GetAllDevices())
+                .Returns(new[]
+                {
+                    _testData.Org1Device2,
+                    _testData.Org2Device1
+                });
+
+            var connectionId = "HQUSIBxiOwNokVH_mYgGyg";
+
+            _agentSessionCache
+                .Setup(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId))
+                .Returns(true);
+
+            var wakeResult = await _circuitConnection.WakeDevices(new[] { _testData.Org1Device1 });
+
+            Assert.IsTrue(addToGroupResult);
+            Assert.IsTrue(wakeResult.IsSuccess);
+
+
+            _agentSessionCache
+                .Verify(x => x.GetAllDevices(), Times.Once);
+
+            _agentSessionCache
+                .Verify(x => x.TryGetConnectionId(_testData.Org1Device2.ID, out connectionId), Times.Once);
+
+            _agentHubContextFixture.HubClientsMock
+                .Verify(x => x.Client(connectionId), Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock
+                .Verify(x =>
+                    x.SendCoreAsync(
+                        "WakeDevice",
+                        new object[] { macAddress },
+                        default),
+                        Times.Once);
+
+            _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
+            _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
+            _agentSessionCache.VerifyNoOtherCalls();
+        }
+
+    }
+}

--- a/Tests/Server.Tests/DataServiceTests.cs
+++ b/Tests/Server.Tests/DataServiceTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Remotely.Server.Services;
+using Remotely.Shared.Dtos;
 using Remotely.Shared.Models;
 using Remotely.Shared.Utilities;
 using System;
@@ -35,10 +36,10 @@ namespace Remotely.Tests
 
             Assert.IsNull(storedDevice);
 
-            var newDevice = new Device()
+            var newDevice = new DeviceClientDto()
             {
-                ID = _newDeviceID,
-                OrganizationID = _testData.Org1Id,
+                Id = _newDeviceID,
+                OrganizationId = _testData.Org1Id,
                 DeviceName = Environment.MachineName,
                 Is64Bit = Environment.Is64BitOperatingSystem
             };

--- a/Tests/Server.Tests/DataServiceTests.cs
+++ b/Tests/Server.Tests/DataServiceTests.cs
@@ -21,9 +21,9 @@ namespace Remotely.Tests
         [TestMethod]
         public async Task AddAlert()
         {
-            await _dataService.AddAlert(_testData.Device1.ID, _testData.OrganizationID, "Test Message");
+            await _dataService.AddAlert(_testData.Org1Device1.ID, _testData.Org1Id, "Test Message");
 
-            var alerts = _dataService.GetAlerts(_testData.Admin1.Id);
+            var alerts = _dataService.GetAlerts(_testData.Org1Admin1.Id);
 
             Assert.AreEqual("Test Message", alerts.First().Message);
         }
@@ -38,7 +38,7 @@ namespace Remotely.Tests
             var newDevice = new Device()
             {
                 ID = _newDeviceID,
-                OrganizationID = _testData.OrganizationID,
+                OrganizationID = _testData.Org1Id,
                 DeviceName = Environment.MachineName,
                 Is64Bit = Environment.Is64BitOperatingSystem
             };
@@ -60,7 +60,7 @@ namespace Remotely.Tests
             {
                 DeviceID = Guid.NewGuid().ToString(),
                 DeviceAlias = "Spare Laptop",
-                OrganizationID = _testData.OrganizationID
+                OrganizationID = _testData.Org1Id
             };
 
             // First call should create and return device.
@@ -75,32 +75,32 @@ namespace Remotely.Tests
         [TestMethod]
         public void DeviceGroupPermissions()
         {
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Admin1.UserName).Count() == 2);
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Admin2.UserName).Count() == 2);
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.User1.UserName).Count() == 2);
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.User2.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1Admin1.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1Admin2.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1User1.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1User2.UserName).Count() == 2);
 
-            var groupID = _dataService.GetDeviceGroups(_testData.Admin1.UserName).First().ID;
+            var groupID = _dataService.GetDeviceGroups(_testData.Org1Admin1.UserName).First().ID;
 
-            _dataService.UpdateDevice(_testData.Device1.ID, "", "", groupID, "");
-            _dataService.AddUserToDeviceGroup(_testData.OrganizationID, groupID, _testData.User1.UserName, out _);
+            _dataService.UpdateDevice(_testData.Org1Device1.ID, "", "", groupID, "");
+            _dataService.AddUserToDeviceGroup(_testData.Org1Id, groupID, _testData.Org1User1.UserName, out _);
 
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Admin1.UserName).Count() == 2);
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Admin2.UserName).Count() == 2);
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.User1.UserName).Count() == 2);
-            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.User2.UserName).Count() == 1);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1Admin1.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1Admin2.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1User1.UserName).Count() == 2);
+            Assert.IsTrue(_dataService.GetDevicesForUser(_testData.Org1User2.UserName).Count() == 1);
 
-            Assert.IsTrue(_dataService.DoesUserHaveAccessToDevice(_testData.Device1.ID, _testData.Admin1));
-            Assert.IsTrue(_dataService.DoesUserHaveAccessToDevice(_testData.Device1.ID, _testData.Admin2));
-            Assert.IsTrue(_dataService.DoesUserHaveAccessToDevice(_testData.Device1.ID, _testData.User1));
-            Assert.IsFalse(_dataService.DoesUserHaveAccessToDevice(_testData.Device1.ID, _testData.User2));
+            Assert.IsTrue(_dataService.DoesUserHaveAccessToDevice(_testData.Org1Device1.ID, _testData.Org1Admin1));
+            Assert.IsTrue(_dataService.DoesUserHaveAccessToDevice(_testData.Org1Device1.ID, _testData.Org1Admin2));
+            Assert.IsTrue(_dataService.DoesUserHaveAccessToDevice(_testData.Org1Device1.ID, _testData.Org1User1));
+            Assert.IsFalse(_dataService.DoesUserHaveAccessToDevice(_testData.Org1Device1.ID, _testData.Org1User2));
 
-            var allDevices = _dataService.GetAllDevices(_testData.OrganizationID).Select(x => x.ID).ToArray();
+            var allDevices = _dataService.GetAllDevices(_testData.Org1Id).Select(x => x.ID).ToArray();
 
-            Assert.AreEqual(2, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.Admin1).Length);
-            Assert.AreEqual(2, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.Admin2).Length);
-            Assert.AreEqual(2, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.User1).Length);
-            Assert.AreEqual(1, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.User2).Length);
+            Assert.AreEqual(2, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.Org1Admin1).Length);
+            Assert.AreEqual(2, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.Org1Admin2).Length);
+            Assert.AreEqual(2, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.Org1User1).Length);
+            Assert.AreEqual(1, _dataService.FilterDeviceIDsByUserPermission(allDevices, _testData.Org1User2).Length);
         }
 
         [TestMethod]
@@ -111,25 +111,25 @@ namespace Remotely.Tests
             var savedScript = new SavedScript()
             {
                 Content = "Get-ChildItem",
-                Creator = _testData.Admin1,
-                CreatorId = _testData.Admin1.Id,
+                Creator = _testData.Org1Admin1,
+                CreatorId = _testData.Org1Admin1.Id,
                 Name = "GCI",
-                Organization = _testData.Admin1.Organization,
-                OrganizationID = _testData.OrganizationID,
+                Organization = _testData.Org1Admin1.Organization,
+                OrganizationID = _testData.Org1Id,
                 Shell = Shared.Enums.ScriptingShell.PSCore
             };
 
-            await _dataService.AddOrUpdateSavedScript(savedScript, _testData.Admin1.Id);
+            await _dataService.AddOrUpdateSavedScript(savedScript, _testData.Org1Admin1.Id);
 
             var scriptRun = new ScriptRun()
             {
-                Devices = new() { _testData.Device1 },
+                Devices = new() { _testData.Org1Device1 },
                 InputType = Shared.Enums.ScriptInputType.ScheduledScript,
                 SavedScriptId = savedScript.Id,
-                Initiator = _testData.Admin1.UserName,
+                Initiator = _testData.Org1Admin1.UserName,
                 RunAt = now,
-                OrganizationID = _testData.OrganizationID,
-                Organization = _testData.Admin1.Organization,
+                OrganizationID = _testData.Org1Id,
+                Organization = _testData.Org1Admin1.Organization,
                 RunOnNextConnect = true
             };
 
@@ -142,16 +142,16 @@ namespace Remotely.Tests
 
             Time.Adjust(TimeSpan.FromMinutes(2));
 
-            var pendingRuns = await _dataService.GetPendingScriptRuns(_testData.Device1.ID);
+            var pendingRuns = await _dataService.GetPendingScriptRuns(_testData.Org1Device1.ID);
 
             Assert.AreEqual(1, pendingRuns.Count);
             Assert.AreEqual(2, pendingRuns[0].Id);
 
             var scriptResult = new ScriptResult()
             {
-                DeviceID = _testData.Device1.ID,
+                DeviceID = _testData.Org1Device1.ID,
                 InputType = Shared.Enums.ScriptInputType.ScheduledScript,
-                OrganizationID = _testData.OrganizationID,
+                OrganizationID = _testData.Org1Id,
                 SavedScriptId = savedScript.Id,
                 ScriptRunId = scriptRun.Id,
                 Shell = Shared.Enums.ScriptingShell.PSCore
@@ -161,7 +161,7 @@ namespace Remotely.Tests
 
             await _dataService.AddScriptResultToScriptRun(scriptResult.ID, scriptRun.Id);
 
-            pendingRuns = await _dataService.GetPendingScriptRuns(_testData.Device1.ID);
+            pendingRuns = await _dataService.GetPendingScriptRuns(_testData.Org1Device1.ID);
 
             Assert.AreEqual(0, pendingRuns.Count);
         }
@@ -174,9 +174,10 @@ namespace Remotely.Tests
         }
 
         [TestInitialize]
-        public void TestInit()
+        public async Task TestInit()
         {
             _testData = new TestData();
+            await _testData.Init();
             _dataService = IoCActivator.ServiceProvider.GetRequiredService<IDataService>();
 
             var newDevice = new Device()
@@ -184,16 +185,16 @@ namespace Remotely.Tests
                 ID = _newDeviceID,
                 DeviceName = Environment.MachineName,
                 Is64Bit = Environment.Is64BitOperatingSystem,
-                OrganizationID = _testData.OrganizationID
+                OrganizationID = _testData.Org1Id
             };
         }
 
         [TestMethod]
         public void UpdateOrganizationName()
         {
-            Assert.IsTrue(string.IsNullOrWhiteSpace(_testData.Admin1.Organization.OrganizationName));
-            _dataService.UpdateOrganizationName(_testData.OrganizationID, "Test Org");
-            var updatedOrg = _dataService.GetOrganizationById(_testData.OrganizationID);
+            Assert.IsTrue(string.IsNullOrWhiteSpace(_testData.Org1Admin1.Organization.OrganizationName));
+            _dataService.UpdateOrganizationName(_testData.Org1Id, "Test Org");
+            var updatedOrg = _dataService.GetOrganizationById(_testData.Org1Id);
             Assert.AreEqual("Test Org", updatedOrg.OrganizationName);
         }
 
@@ -204,57 +205,75 @@ namespace Remotely.Tests
 
             Assert.AreEqual(1, currentAdmins.Count);
 
-            await _dataService.SetIsServerAdmin(_testData.Admin2.Id, true, _testData.Admin1.Id);
+            await _dataService.SetIsServerAdmin(_testData.Org1Admin2.Id, true, _testData.Org1Admin1.Id);
 
             currentAdmins = _dataService.GetServerAdmins();
             Assert.AreEqual(2, currentAdmins.Count);
-            Assert.IsTrue(currentAdmins.Contains(_testData.Admin1.UserName));
-            Assert.IsTrue(currentAdmins.Contains(_testData.Admin2.UserName));
+            Assert.IsTrue(currentAdmins.Contains(_testData.Org1Admin1.UserName));
+            Assert.IsTrue(currentAdmins.Contains(_testData.Org1Admin2.UserName));
 
             // Shouldn't be able to change themselves.
-            await _dataService.SetIsServerAdmin(_testData.Admin2.Id, false, _testData.Admin2.Id);
+            await _dataService.SetIsServerAdmin(_testData.Org1Admin2.Id, false, _testData.Org1Admin2.Id);
             currentAdmins = _dataService.GetServerAdmins();
             Assert.AreEqual(2, currentAdmins.Count);
 
             // Non-admins shouldn't be able to change admins.
-            await _dataService.SetIsServerAdmin(_testData.User1.Id, false, _testData.Admin2.Id);
+            await _dataService.SetIsServerAdmin(_testData.Org1User1.Id, false, _testData.Org1Admin2.Id);
             currentAdmins = _dataService.GetServerAdmins();
             Assert.AreEqual(2, currentAdmins.Count);
 
-            await _dataService.SetIsServerAdmin(_testData.Admin2.Id, false, _testData.Admin1.Id);
+            await _dataService.SetIsServerAdmin(_testData.Org1Admin2.Id, false, _testData.Org1Admin1.Id);
             currentAdmins = _dataService.GetServerAdmins();
             Assert.AreEqual(1, currentAdmins.Count);
-            Assert.AreEqual(_testData.Admin1.UserName, currentAdmins[0]);
+            Assert.AreEqual(_testData.Org1Admin1.UserName, currentAdmins[0]);
         }
 
         [TestMethod]
         public void VerifyInitialData()
         {
-            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.Admin1.UserName));
-            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.Admin2.UserName));
-            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.User1.UserName));
-            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.User2.UserName));
-            Assert.AreEqual(1, _dataService.GetOrganizationCount());
+            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.Org1Admin1.UserName));
+            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.Org1Admin2.UserName));
+            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.Org1User1.UserName));
+            Assert.IsNotNull(_dataService.GetUserByNameWithOrg(_testData.Org1User2.UserName));
+            Assert.AreEqual(2, _dataService.GetOrganizationCount());
 
-            var devices = _dataService.GetAllDevices(_testData.OrganizationID);
+            var devices1 = _dataService.GetAllDevices(_testData.Org1Id);
+            Assert.AreEqual(2, devices1.Length);
+            Assert.IsTrue(devices1.Any(x => x.ID == "Org1Device1"));
+            Assert.IsTrue(devices1.Any(x => x.ID == "Org1Device2"));
 
-            Assert.AreEqual(2, devices.Count());
-            Assert.IsTrue(devices.Any(x => x.ID == "Device1"));
-            Assert.IsTrue(devices.Any(x => x.ID == "Device2"));
+            var devices2 = _dataService.GetAllDevices(_testData.Org2Id);
+            Assert.AreEqual(2, devices2.Length);
+            Assert.IsTrue(devices2.Any(x => x.ID == "Org2Device1"));
+            Assert.IsTrue(devices2.Any(x => x.ID == "Org2Device2"));
 
-            var orgIDs = new string[]
+            var org1Ids = new string[]
             {
-                _testData.Group1.OrganizationID,
-                _testData.Group2.OrganizationID,
-                _testData.Admin1.OrganizationID,
-                _testData.Admin2.OrganizationID,
-                _testData.User1.OrganizationID,
-                _testData.User2.OrganizationID,
-                _testData.Device1.OrganizationID,
-                _testData.Device2.OrganizationID
+                _testData.Org1Group1.OrganizationID,
+                _testData.Org1Group2.OrganizationID,
+                _testData.Org1Admin1.OrganizationID,
+                _testData.Org1Admin2.OrganizationID,
+                _testData.Org1User1.OrganizationID,
+                _testData.Org1User2.OrganizationID,
+                _testData.Org1Device1.OrganizationID,
+                _testData.Org1Device2.OrganizationID
             };
 
-            Assert.IsTrue(orgIDs.All(x => x == _testData.OrganizationID));
+            Assert.IsTrue(org1Ids.All(x => x == _testData.Org1Id));
+
+            var org2Ids = new string[]
+{
+                _testData.Org2Group1.OrganizationID,
+                _testData.Org2Group2.OrganizationID,
+                _testData.Org2Admin1.OrganizationID,
+                _testData.Org2Admin2.OrganizationID,
+                _testData.Org2User1.OrganizationID,
+                _testData.Org2User2.OrganizationID,
+                _testData.Org2Device1.OrganizationID,
+                _testData.Org2Device2.OrganizationID
+};
+
+            Assert.IsTrue(org2Ids.All(x => x == _testData.Org2Id));
         }
     }
 }

--- a/Tests/Server.Tests/Mocks/HubContextFixture.cs
+++ b/Tests/Server.Tests/Mocks/HubContextFixture.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using Moq;
+using Remotely.Server.Hubs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Remotely.Server.Tests.Mocks
+{
+    public class HubContextFixture<T>
+        where T : Hub
+    {
+        public HubContextFixture()
+        { 
+            HubContextMock = new Mock<IHubContext<T>>();
+            HubClientsMock = new Mock<IHubClients>();
+            GroupManagerMock = new Mock<IGroupManager>();
+            SingleClientProxyMock = new Mock<ISingleClientProxy>();
+            ClientProxyMock = new Mock<IClientProxy>();
+
+            HubContextMock
+                .Setup(x => x.Clients)
+                .Returns(HubClientsMock.Object);
+
+            HubContextMock
+              .Setup(x => x.Groups)
+              .Returns(GroupManagerMock.Object);
+
+            HubClientsMock
+                .Setup(x => x.Client(It.IsAny<string>()))
+                .Returns(SingleClientProxyMock.Object);
+
+            HubClientsMock
+                .Setup(x => x.Group(It.IsAny<string>()))
+                .Returns(ClientProxyMock.Object);
+        }
+
+        public Mock<IHubContext<T>> HubContextMock { get; }
+        public Mock<IHubClients> HubClientsMock { get; }
+        public Mock<IGroupManager> GroupManagerMock { get; }
+        public Mock<ISingleClientProxy> SingleClientProxyMock { get; }
+        public Mock<IClientProxy> ClientProxyMock { get; }
+    }
+}

--- a/Tests/Server.Tests/TestData.cs
+++ b/Tests/Server.Tests/TestData.cs
@@ -14,49 +14,89 @@ namespace Remotely.Tests
 {
     public class TestData
     {
-        public TestData()
-        {
-            Init().Wait();
-        }
+        #region Organization1
+        public Organization Org1 => Org1Admin1.Organization;
 
-        public RemotelyUser Admin1 { get; } = new RemotelyUser()
+        public RemotelyUser Org1Admin1 { get; } = new()
         {
-            UserName = "admin1@test.com",
+            UserName = "org1admin1@test.com",
             IsAdministrator = true,
             IsServerAdmin = true,
             Organization = new Organization(),
             UserOptions = new RemotelyUserOptions()
         };
 
-        public RemotelyUser Admin2 { get; private set; } 
+        public RemotelyUser Org1Admin2 { get; private set; } 
 
-        public Device Device1 { get; private set; } = new Device()
+        public Device Org1Device1 { get; private set; } = new Device()
         {
-            ID = "Device1",
-            DeviceName = "Device1Name"
+            ID = "Org1Device1",
+            DeviceName = "Org1Device1Name"
         };
 
-        public Device Device2 { get; private set; } = new Device()
+        public Device Org1Device2 { get; private set; } = new Device()
         {
-            ID = "Device2",
-            DeviceName = "Device2Name"
+            ID = "Org1Device2",
+            DeviceName = "Org1Device2Name"
         };
 
-        public DeviceGroup Group1 { get; private set; } = new DeviceGroup()
+        public DeviceGroup Org1Group1 { get; private set; } = new DeviceGroup()
         {
-            Name = "Group1"
+            Name = "Org1Group1"
         };
 
-        public DeviceGroup Group2 { get; private set; } = new DeviceGroup()
+        public DeviceGroup Org1Group2 { get; private set; } = new DeviceGroup()
         {
-            Name = "Group2"
+            Name = "Org1Group2"
         };
 
-        public string OrganizationID { get; private set; }
+        public string Org1Id => Org1.ID;
+        public RemotelyUser Org1User1 { get; private set; }
+        public RemotelyUser Org1User2 { get; private set; }
+        #endregion
 
-        public RemotelyUser User1 { get; private set; }
 
-        public RemotelyUser User2 { get; private set; }
+
+        #region Organization2
+        public Organization Org2 => Org2Admin1.Organization;
+
+        public RemotelyUser Org2Admin1 { get; } = new()
+        {
+            UserName = "org2admin1@test.com",
+            IsAdministrator = true,
+            IsServerAdmin = false,
+            Organization = new Organization(),
+            UserOptions = new RemotelyUserOptions()
+        };
+
+        public RemotelyUser Org2Admin2 { get; private set; }
+
+        public Device Org2Device1 { get; private set; } = new Device()
+        {
+            ID = "Org2Device1",
+            DeviceName = "Org2Device1Name"
+        };
+
+        public Device Org2Device2 { get; private set; } = new Device()
+        {
+            ID = "Org2Device2",
+            DeviceName = "Org2Device2Name"
+        };
+
+        public DeviceGroup Org2Group1 { get; private set; } = new DeviceGroup()
+        {
+            Name = "Org2Group1"
+        };
+
+        public DeviceGroup Org2Group2 { get; private set; } = new DeviceGroup()
+        {
+            Name = "Org2Group2"
+        };
+
+        public string Org2Id => Org2.ID;
+        public RemotelyUser Org2User1 { get; private set; }
+        public RemotelyUser Org2User2 { get; private set; }
+        #endregion
 
         public void ClearData()
         {
@@ -74,7 +114,7 @@ namespace Remotely.Tests
 
         }
 
-        private async Task Init()
+        public async Task Init()
         {
             ClearData();
 
@@ -82,29 +122,52 @@ namespace Remotely.Tests
             var userManager = IoCActivator.ServiceProvider.GetRequiredService<UserManager<RemotelyUser>>();
             var emailSender = IoCActivator.ServiceProvider.GetRequiredService<IEmailSenderEx>();
 
-            await userManager.CreateAsync(Admin1);
+            // Organization 1
+            await userManager.CreateAsync(Org1Admin1);
 
-            await dataService.CreateUser("admin2@test.com", true, Admin1.OrganizationID);
-            Admin2 = dataService.GetUserByNameWithOrg("admin2@test.com");
+            await dataService.CreateUser("org1admin2@test.com", true, Org1Admin1.OrganizationID);
+            Org1Admin2 = dataService.GetUserByNameWithOrg("org1admin2@test.com");
 
-            await dataService.CreateUser("testuser1@test.com", false, Admin1.OrganizationID);
-            User1 = dataService.GetUserByNameWithOrg("testuser1@test.com");
+            await dataService.CreateUser("org1testuser1@test.com", false, Org1Admin1.OrganizationID);
+            Org1User1 = dataService.GetUserByNameWithOrg("org1testuser1@test.com");
 
-            await dataService.CreateUser("testuser2@test.com", false, Admin1.OrganizationID);
-            User2 = dataService.GetUserByNameWithOrg("testuser2@test.com");
+            await dataService.CreateUser("org1testuser2@test.com", false, Org1Admin1.OrganizationID);
+            Org1User2 = dataService.GetUserByNameWithOrg("org1testuser2@test.com");
 
-            Device1.OrganizationID = Admin1.OrganizationID;
-            await dataService.AddOrUpdateDevice(Device1); ;
-            Device2.OrganizationID = Admin1.OrganizationID;
-            await dataService.AddOrUpdateDevice(Device2);
+            Org1Device1.OrganizationID = Org1Admin1.OrganizationID;
+            await dataService.AddOrUpdateDevice(Org1Device1); ;
+            Org1Device2.OrganizationID = Org1Admin1.OrganizationID;
+            await dataService.AddOrUpdateDevice(Org1Device2);
 
-            dataService.AddDeviceGroup(Admin1.OrganizationID, Group1, out _, out _);
-            dataService.AddDeviceGroup(Admin1.OrganizationID, Group2, out _, out _);
-            var deviceGroups = dataService.GetDeviceGroups(Admin1.UserName);
-            Group1 = deviceGroups.First(x => x.Name == Group1.Name);
-            Group2 = deviceGroups.First(x => x.Name == Group2.Name);
+            dataService.AddDeviceGroup(Org1Admin1.OrganizationID, Org1Group1, out _, out _);
+            dataService.AddDeviceGroup(Org1Admin1.OrganizationID, Org1Group2, out _, out _);
+            var deviceGroups1 = dataService.GetDeviceGroups(Org1Admin1.UserName);
+            Org1Group1 = deviceGroups1.First(x => x.Name == Org1Group1.Name);
+            Org1Group2 = deviceGroups1.First(x => x.Name == Org1Group2.Name);
 
-            OrganizationID = Admin1.OrganizationID;
+
+            // Organization 2
+            await userManager.CreateAsync(Org2Admin1);
+
+            await dataService.CreateUser("org2admin2@test.com", true, Org2Admin1.OrganizationID);
+            Org2Admin2 = dataService.GetUserByNameWithOrg("org2admin2@test.com");
+
+            await dataService.CreateUser("org2testuser1@test.com", false, Org2Admin1.OrganizationID);
+            Org2User1 = dataService.GetUserByNameWithOrg("org2testuser1@test.com");
+
+            await dataService.CreateUser("org2testuser2@test.com", false, Org2Admin1.OrganizationID);
+            Org2User2 = dataService.GetUserByNameWithOrg("org2testuser2@test.com");
+
+            Org2Device1.OrganizationID = Org2Admin1.OrganizationID;
+            await dataService.AddOrUpdateDevice(Org2Device1); ;
+            Org2Device2.OrganizationID = Org2Admin1.OrganizationID;
+            await dataService.AddOrUpdateDevice(Org2Device2);
+
+            dataService.AddDeviceGroup(Org2Admin1.OrganizationID, Org2Group1, out _, out _);
+            dataService.AddDeviceGroup(Org2Admin1.OrganizationID, Org2Group2, out _, out _);
+            var deviceGroups2 = dataService.GetDeviceGroups(Org2Admin1.UserName);
+            Org2Group1 = deviceGroups2.First(x => x.Name == Org2Group1.Name);
+            Org2Group2 = deviceGroups2.First(x => x.Name == Org2Group2.Name);
         }
     }
 }


### PR DESCRIPTION
This PR adds Wake-on-LAN feature.  It can be triggered for an individual device or a device group.  The server will look for devices that are eligible to wake the offline device by matching either the device group or the public IP address.

Other Changes:
- Removed some old code.
- Renamed `AgentHubSessionCache` (formerly "Service").
- Added new overload to `ToastService`.
- Reduced the initial load of server logs to 1 day.
- Changed `IMessenger` registration from Singleton to Scoped.
  - Scoped is essentially per-connection singleton in Blazor Server.
  - Singleton was causing events to trigger in other tabs.
- Expanded test data.
- Changed authorization behavior so devices that aren't in groups are no longer considered "public".
  - This was a workaround for a legacy issue that no longer exists.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
