### PR TITLE
Realign property name casing in DeviceClientDto. 

### DIFF
--- a/Agent/Services/AgentHubConnection.cs
+++ b/Agent/Services/AgentHubConnection.cs
@@ -109,7 +109,6 @@ namespace Remotely.Agent.Services
 
                     _logger.LogInformation("Connected to server.");
 
-                    // TODO: Move CPU sampler to background service.
                     var device = await _deviceInfoService.CreateDevice(_connectionInfo.DeviceID, _connectionInfo.OrganizationID);
 
                     var result = await _hubConnection.InvokeAsync<bool>("DeviceCameOnline", device);
@@ -199,6 +198,8 @@ namespace Remotely.Agent.Services
         private async Task HubConnection_Reconnected(string arg)
         {
             _logger.LogInformation("Reconnected to server.");
+            await _updater.CheckForUpdates();
+
             var device = await _deviceInfoService.CreateDevice(_connectionInfo.DeviceID, _connectionInfo.OrganizationID);
 
             if (!await _hubConnection.InvokeAsync<bool>("DeviceCameOnline", device))
@@ -212,9 +213,8 @@ namespace Remotely.Agent.Services
                 await Connect();
                 return;
             }
-
-            await _updater.CheckForUpdates();
         }
+
         private void RegisterMessageHandlers()
         {
 

--- a/Agent/Services/DeviceInfoGeneratorBase.cs
+++ b/Agent/Services/DeviceInfoGeneratorBase.cs
@@ -27,16 +27,16 @@ namespace Remotely.Agent.Services
 
             return new DeviceClientDto()
             {
-                Id = deviceID,
+                ID = deviceID,
                 DeviceName = Environment.MachineName,
                 Platform = EnvironmentHelper.Platform.ToString(),
                 ProcessorCount = Environment.ProcessorCount,
-                OsArchitecture = RuntimeInformation.OSArchitecture,
-                OsDescription = RuntimeInformation.OSDescription,
+                OSArchitecture = RuntimeInformation.OSArchitecture,
+                OSDescription = RuntimeInformation.OSDescription,
                 Is64Bit = Environment.Is64BitOperatingSystem,
                 IsOnline = true,
                 MacAddresses = GetMacAddresses().ToArray(),
-                OrganizationId = orgID,
+                OrganizationID = orgID,
                 AgentVersion = AppVersionHelper.GetAppVersion()
         };
         }

--- a/Server/Hubs/AgentHub.cs
+++ b/Server/Hubs/AgentHub.cs
@@ -92,7 +92,7 @@ namespace Remotely.Server.Hubs
         {
             try
             {
-                if (CheckForDeviceBan(device.Id, device.DeviceName))
+                if (CheckForDeviceBan(device.ID, device.DeviceName))
                 {
                     return false;
                 }
@@ -147,7 +147,7 @@ namespace Remotely.Server.Hubs
 
         public async Task DeviceHeartbeat(DeviceClientDto device)
         {
-            if (CheckForDeviceBan(device.Id, device.DeviceName))
+            if (CheckForDeviceBan(device.ID, device.DeviceName))
             {
                 return;
             }

--- a/Server/Services/DataService.cs
+++ b/Server/Services/DataService.cs
@@ -360,14 +360,14 @@ namespace Remotely.Server.Services
         {
             using var dbContext = _appDbFactory.GetContext();
 
-            var device = await dbContext.Devices.FindAsync(deviceDto.Id);
+            var device = await dbContext.Devices.FindAsync(deviceDto.ID);
 
             if (device is null)
             {
                 device = new Device
                 {
-                    OrganizationID = deviceDto.OrganizationId,
-                    ID = deviceDto.Id,
+                    OrganizationID = deviceDto.OrganizationID,
+                    ID = deviceDto.ID,
                 };
                 await dbContext.Devices.AddAsync(device);
             }
@@ -380,8 +380,8 @@ namespace Remotely.Server.Services
             device.UsedStorage = deviceDto.UsedStorage;
             device.Is64Bit = deviceDto.Is64Bit;
             device.IsOnline = true;
-            device.OSArchitecture = deviceDto.OsArchitecture;
-            device.OSDescription = deviceDto.OsDescription;
+            device.OSArchitecture = deviceDto.OSArchitecture;
+            device.OSDescription = deviceDto.OSDescription;
             device.Platform = deviceDto.Platform;
             device.ProcessorCount = deviceDto.ProcessorCount;
             device.PublicIP = deviceDto.PublicIP;

--- a/Shared/Dtos/DeviceClientDto.cs
+++ b/Shared/Dtos/DeviceClientDto.cs
@@ -29,7 +29,7 @@ namespace Remotely.Shared.Dtos
         public List<Drive> Drives { get; set; } = new();
 
         [DataMember]
-        public string Id { get; set; } = string.Empty;
+        public string ID { get; set; } = string.Empty;
 
         [DataMember]
         public bool Is64Bit { get; set; }
@@ -41,13 +41,13 @@ namespace Remotely.Shared.Dtos
         public string[] MacAddresses { get; set; } = Array.Empty<string>();
 
         [DataMember]
-        public string OrganizationId { get; set; } = string.Empty;
+        public string OrganizationID { get; set; } = string.Empty;
 
         [DataMember]
-        public Architecture OsArchitecture { get; set; }
+        public Architecture OSArchitecture { get; set; }
 
         [DataMember]
-        public string OsDescription { get; set; } = string.Empty;
+        public string OSDescription { get; set; } = string.Empty;
 
         [DataMember]
         public string Platform { get; set; } = string.Empty;

--- a/Tests/LoadTester/Program.cs
+++ b/Tests/LoadTester/Program.cs
@@ -116,7 +116,7 @@ internal class Program
                     {
                         try
                         {
-                            var currentInfo = await _deviceInfo.CreateDevice(device.Id, _organizationId);
+                            var currentInfo = await _deviceInfo.CreateDevice(device.ID, _organizationId);
                             currentInfo.DeviceName = device.DeviceName;
                             await hubConnection.SendAsync("DeviceHeartbeat", currentInfo);
                         }

--- a/Tests/Server.Tests/DataServiceTests.cs
+++ b/Tests/Server.Tests/DataServiceTests.cs
@@ -38,8 +38,8 @@ namespace Remotely.Tests
 
             var newDevice = new DeviceClientDto()
             {
-                Id = _newDeviceID,
-                OrganizationId = _testData.Org1Id,
+                ID = _newDeviceID,
+                OrganizationID = _testData.Org1Id,
                 DeviceName = Environment.MachineName,
                 Is64Bit = Environment.Is64BitOperatingSystem
             };

--- a/Tests/Server.Tests/TestData.cs
+++ b/Tests/Server.Tests/TestData.cs
@@ -116,15 +116,15 @@ namespace Remotely.Tests
 
             var device1 = new DeviceClientDto()
             {
-                Id = "Org1Device1",
+                ID = "Org1Device1",
                 DeviceName = "Org1Device1Name",
-                OrganizationId = Org1Id
+                OrganizationID = Org1Id
             };
             var device2 = new DeviceClientDto()
             {
-                Id = "Org1Device2",
+                ID = "Org1Device2",
                 DeviceName = "Org1Device2Name",
-                OrganizationId = Org1Id
+                OrganizationID = Org1Id
             };
             Org1Device1 = (await dataService.AddOrUpdateDevice(device1)).Value;
             Org1Device2 = (await dataService.AddOrUpdateDevice(device2)).Value;
@@ -150,15 +150,15 @@ namespace Remotely.Tests
 
             var device3 = new DeviceClientDto()
             {
-                Id = "Org2Device1",
+                ID = "Org2Device1",
                 DeviceName = "Org2Device1Name",
-                OrganizationId = Org2Id
+                OrganizationID = Org2Id
             };
             var device4 = new DeviceClientDto()
             {
-                Id = "Org2Device2",
+                ID = "Org2Device2",
                 DeviceName = "Org2Device2Name",
-                OrganizationId = Org2Id
+                OrganizationID = Org2Id
             };
             Org2Device1 = (await dataService.AddOrUpdateDevice(device3)).Value;
             Org2Device2 = (await dataService.AddOrUpdateDevice(device4)).Value;


### PR DESCRIPTION
`DeviceClientDto`'s property name casings were out of alignment with `Device`.  This created a serialization issue when agents first try to connect to an updated server.  I didn't realize that the agent auto-update wouldn't happen immediately after reconnect if the `DeviceCameOnline` method failed.

I moved the update check to immediately after reconnect, so we can have breaking API changes like this later without any issues.  For now, I realigned the property name casings.  After this release, they can be corrected.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
