### PR TITLE
Fix running scripts.

### DIFF
--- a/Server/Components/Scripts/RunScript.razor.cs
+++ b/Server/Components/Scripts/RunScript.razor.cs
@@ -123,7 +123,7 @@ namespace Remotely.Server.Components.Scripts
 
             var filteredDevices = DataService.FilterDeviceIDsByUserPermission(deviceIds.ToArray(), User);
 
-            var onlineDevices = ServiceSessionCache.GetConnectionIdsByDeviceIds(filteredDevices);
+            var onlineDevices = ServiceSessionCache.FilterDevicesByOnlineStatus(filteredDevices, true);
 
             var scriptRun = new ScriptRun()
             {

--- a/Server/Services/AgentHubSessionCache.cs
+++ b/Server/Services/AgentHubSessionCache.cs
@@ -9,6 +9,8 @@ namespace Remotely.Server.Services
     public interface IAgentHubSessionCache
     {
         void AddOrUpdateByConnectionId(string connectionId, Device device);
+        IEnumerable<string> FilterDevicesByOnlineStatus(IEnumerable<string> deviceIds, bool isOnline);
+
         ICollection<Device> GetAllDevices();
         IEnumerable<string> GetConnectionIdsByDeviceIds(IEnumerable<string> deviceIds);
         bool TryGetByDeviceId(string deviceId, out Device device);
@@ -26,6 +28,18 @@ namespace Remotely.Server.Services
         {
             _connectionIdToDeviceLookup.AddOrUpdate(connectionId, device, (k, v) => device);
             _deviceIdToConnectionIdLookup.AddOrUpdate(device.ID, connectionId, (k, v) => connectionId);
+        }
+
+        public IEnumerable<string> FilterDevicesByOnlineStatus(IEnumerable<string> deviceIds, bool isOnline)
+        {
+            foreach (var deviceId in deviceIds)
+            {
+                var result = TryGetConnectionId(deviceId, out _);
+                if (result == isOnline)
+                {
+                    yield return deviceId;
+                }
+            }
         }
 
         public ICollection<Device> GetAllDevices() => _connectionIdToDeviceLookup.Values;

--- a/Server/Services/ScriptScheduleDispatcher.cs
+++ b/Server/Services/ScriptScheduleDispatcher.cs
@@ -85,7 +85,7 @@ namespace Remotely.Server.Services
                             .Distinct()
                             .ToArray();
 
-                        var onlineDevices = _serviceSessionCache.GetConnectionIdsByDeviceIds(deviceIds);
+                        var onlineDevices = _serviceSessionCache.FilterDevicesByOnlineStatus(deviceIds, true);
 
                         if (schedule.RunOnNextConnect)
                         {


### PR DESCRIPTION
Added `AgentHubSessionCache.FilterDevicesByOnlineStatus` for use by script runner.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
