### PR TITLE
Refactor services in Agent project.

### DIFF
--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -94,12 +94,12 @@ public class Program
         services.AddSingleton<ICpuUtilizationSampler, CpuUtilizationSampler>();
         services.AddSingleton<IWakeOnLanService, WakeOnLanService>();
         services.AddHostedService(services => services.GetRequiredService<ICpuUtilizationSampler>());
-        services.AddScoped<ChatClientService>();
-        services.AddTransient<PSCore>();
-        services.AddTransient<ExternalScriptingShell>();
-        services.AddScoped<ConfigService>();
-        services.AddScoped<Uninstaller>();
-        services.AddScoped<ScriptExecutor>();
+        services.AddScoped<IChatClientService, ChatClientService>();
+        services.AddTransient<IPSCore, PSCore>();
+        services.AddTransient<IExternalScriptingShell, ExternalScriptingShell>();
+        services.AddScoped<IConfigService, ConfigService>();
+        services.AddScoped<IUninstaller, Uninstaller>();
+        services.AddScoped<IScriptExecutor, ScriptExecutor>();
         services.AddScoped<IProcessInvoker, ProcessInvoker>();
         services.AddScoped<IUpdateDownloader, UpdateDownloader>();
 

--- a/Agent/Services/AgentHubConnection.cs
+++ b/Agent/Services/AgentHubConnection.cs
@@ -29,20 +29,15 @@ namespace Remotely.Agent.Services
     public class AgentHubConnection : IAgentHubConnection, IDisposable
     {
         private readonly IAppLauncher _appLauncher;
-
-        private readonly ChatClientService _chatService;
-
-        private readonly ConfigService _configService;
-
+        private readonly IChatClientService _chatService;
+        private readonly IConfigService _configService;
         private readonly IDeviceInformationService _deviceInfoService;
         private readonly IHttpClientFactory _httpFactory;
         private readonly IWakeOnLanService _wakeOnLanService;
         private readonly ILogger<AgentHubConnection> _logger;
         private readonly ILogger _fileLogger;
-        private readonly ScriptExecutor _scriptExecutor;
-
-        private readonly Uninstaller _uninstaller;
-
+        private readonly IScriptExecutor _scriptExecutor;
+        private readonly IUninstaller _uninstaller;
         private readonly IUpdater _updater;
 
         private ConnectionInfo _connectionInfo;
@@ -50,10 +45,11 @@ namespace Remotely.Agent.Services
         private Timer _heartbeatTimer;
         private bool _isServerVerified;
 
-        public AgentHubConnection(ConfigService configService,
-            Uninstaller uninstaller,
-            ScriptExecutor scriptExecutor,
-            ChatClientService chatService,
+        public AgentHubConnection(
+            IConfigService configService,
+            IUninstaller uninstaller,
+            IScriptExecutor scriptExecutor,
+            IChatClientService chatService,
             IAppLauncher appLauncher,
             IUpdater updater,
             IDeviceInformationService deviceInfoService,

--- a/Agent/Services/ConfigService.cs
+++ b/Agent/Services/ConfigService.cs
@@ -1,4 +1,5 @@
-﻿using Remotely.Shared.Models;
+﻿using Microsoft.Extensions.Logging;
+using Remotely.Shared.Models;
 using Remotely.Shared.Utilities;
 using System;
 using System.Collections.Generic;
@@ -8,11 +9,23 @@ using System.Text.Json;
 
 namespace Remotely.Agent.Services
 {
-    public class ConfigService
+    public interface IConfigService
+    {
+        ConnectionInfo GetConnectionInfo();
+        void SaveConnectionInfo(ConnectionInfo connectionInfo);
+    }
+
+    public class ConfigService : IConfigService
     {
         private static readonly object _fileLock = new();
         private ConnectionInfo _connectionInfo;
         private readonly string _debugGuid = "f2b0a595-5ea8-471b-975f-12e70e0f3497";
+        private readonly ILogger<ConfigService> _logger;
+
+        public ConfigService(ILogger<ConfigService> logger)
+        {
+            _logger = logger;
+        }
 
         private Dictionary<string, string> _commandLineArgs;
         private Dictionary<string, string> CommandLineArgs
@@ -74,7 +87,7 @@ namespace Remotely.Agent.Services
                 {
                     if (!File.Exists("ConnectionInfo.json"))
                     {
-                        Logger.Write(new Exception("No connection info available.  Please create ConnectionInfo.json file with appropriate values."));
+                        _logger.LogError("No connection info available.  Please create ConnectionInfo.json file with appropriate values.");
                         return null;
                     }
                     _connectionInfo = JsonSerializer.Deserialize<ConnectionInfo>(File.ReadAllText("ConnectionInfo.json"));

--- a/Agent/Services/DeviceInfoGeneratorBase.cs
+++ b/Agent/Services/DeviceInfoGeneratorBase.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 
 namespace Remotely.Agent.Services
 {
-    public class DeviceInfoGeneratorBase
+    public abstract class DeviceInfoGeneratorBase
     {
         protected readonly ILogger<DeviceInfoGeneratorBase> _logger;
 

--- a/Agent/Services/Linux/AppLauncherLinux.cs
+++ b/Agent/Services/Linux/AppLauncherLinux.cs
@@ -24,7 +24,7 @@ namespace Remotely.Agent.Services.Linux
         private readonly ILogger<AppLauncherLinux> _logger;
 
         public AppLauncherLinux(
-            ConfigService configService,
+            IConfigService configService,
             IProcessInvoker processInvoker,
             ILogger<AppLauncherLinux> logger)
         {

--- a/Agent/Services/Linux/UpdaterLinux.cs
+++ b/Agent/Services/Linux/UpdaterLinux.cs
@@ -20,7 +20,7 @@ namespace Remotely.Agent.Services.Linux
     public class UpdaterLinux : IUpdater
     {
         private readonly SemaphoreSlim _checkForUpdatesLock = new(1, 1);
-        private readonly ConfigService _configService;
+        private readonly IConfigService _configService;
         private readonly IUpdateDownloader _updateDownloader;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<UpdaterLinux> _logger;
@@ -29,7 +29,7 @@ namespace Remotely.Agent.Services.Linux
         private DateTimeOffset _lastUpdateFailure;
 
         public UpdaterLinux(
-            ConfigService configService,
+            IConfigService configService,
             IUpdateDownloader updateDownloader,
             IHttpClientFactory httpClientFactory,
             ILogger<UpdaterLinux> logger)

--- a/Agent/Services/MacOS/UpdaterMac.cs
+++ b/Agent/Services/MacOS/UpdaterMac.cs
@@ -21,7 +21,7 @@ namespace Remotely.Agent.Services.MacOS
     {
         private readonly string _achitecture = RuntimeInformation.OSArchitecture.ToString().ToLower();
         private readonly SemaphoreSlim _checkForUpdatesLock = new(1, 1);
-        private readonly ConfigService _configService;
+        private readonly IConfigService _configService;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IUpdateDownloader _updateDownloader;
         private readonly ILogger<UpdaterMac> _logger;
@@ -30,7 +30,7 @@ namespace Remotely.Agent.Services.MacOS
         private readonly System.Timers.Timer _updateTimer = new(TimeSpan.FromHours(6).TotalMilliseconds);
 
         public UpdaterMac(
-            ConfigService configService,
+            IConfigService configService,
             IUpdateDownloader updateDownloader,
             IHttpClientFactory httpClientFactory,
             ILogger<UpdaterMac> logger)

--- a/Agent/Services/Uninstaller.cs
+++ b/Agent/Services/Uninstaller.cs
@@ -6,7 +6,12 @@ using System.IO;
 
 namespace Remotely.Agent.Services
 {
-    public class Uninstaller
+    public interface IUninstaller
+    {
+        void UninstallAgent();
+    }
+
+    public class Uninstaller : IUninstaller
     {
         public void UninstallAgent()
         {

--- a/Agent/Services/Windows/AppLauncherWin.cs
+++ b/Agent/Services/Windows/AppLauncherWin.cs
@@ -22,7 +22,7 @@ namespace Remotely.Agent.Services.Windows
         private readonly ILogger<AppLauncherWin> _logger;
         private readonly string _rcBinaryPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Desktop", EnvironmentHelper.DesktopExecutableFileName);
 
-        public AppLauncherWin(ConfigService configService, ILogger<AppLauncherWin> logger)
+        public AppLauncherWin(IConfigService configService, ILogger<AppLauncherWin> logger)
         {
             _connectionInfo = configService.GetConnectionInfo();
             _logger = logger;

--- a/Agent/Services/Windows/UpdaterWin.cs
+++ b/Agent/Services/Windows/UpdaterWin.cs
@@ -15,7 +15,7 @@ namespace Remotely.Agent.Services.Windows
     public class UpdaterWin : IUpdater
     {
         private readonly SemaphoreSlim _checkForUpdatesLock = new(1, 1);
-        private readonly ConfigService _configService;
+        private readonly IConfigService _configService;
         private readonly IUpdateDownloader _updateDownloader;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<UpdaterWin> _logger;
@@ -25,7 +25,7 @@ namespace Remotely.Agent.Services.Windows
 
 
         public UpdaterWin(
-            ConfigService configService,
+            IConfigService configService,
             IUpdateDownloader updateDownloader,
             IHttpClientFactory httpClientFactory,
             ILogger<UpdaterWin> logger)


### PR DESCRIPTION
- Extracted interfaces from services where missing.
- Registered them in DI under the interface instead of implementation.
- Replaced use of static `Logger` with injected `ILogger<T>`.


---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
