### PR TITLE
Convert AgentHub to use strongly-typed clients.

### DIFF
--- a/Agent/Interfaces/IAppLauncher.cs
+++ b/Agent/Interfaces/IAppLauncher.cs
@@ -8,5 +8,5 @@ public interface IAppLauncher
 {
     Task<int> LaunchChatService(string pipeName, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection);
     Task LaunchRemoteControl(int targetSessionId, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection);
-    Task RestartScreenCaster(List<string> viewerIDs, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1);
+    Task RestartScreenCaster(string[] viewerIds, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1);
 }

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -72,6 +72,8 @@ public class Program
         {
             SetSas(services, logger);
         }
+
+        // TODO: Move this to a BackgroundService.
         await services.GetRequiredService<IUpdater>().BeginChecking();
         await services.GetRequiredService<IAgentHubConnection>().Connect();
     }
@@ -91,34 +93,34 @@ public class Program
         services.AddSingleton<ICpuUtilizationSampler, CpuUtilizationSampler>();
         services.AddSingleton<IWakeOnLanService, WakeOnLanService>();
         services.AddHostedService(services => services.GetRequiredService<ICpuUtilizationSampler>());
-        services.AddScoped<IChatClientService, ChatClientService>();
+        services.AddSingleton<IChatClientService, ChatClientService>();
         services.AddTransient<IPsCoreShell, PsCoreShell>();
         services.AddTransient<IExternalScriptingShell, ExternalScriptingShell>();
-        services.AddScoped<IConfigService, ConfigService>();
-        services.AddScoped<IUninstaller, Uninstaller>();
-        services.AddScoped<IScriptExecutor, ScriptExecutor>();
-        services.AddScoped<IProcessInvoker, ProcessInvoker>();
-        services.AddScoped<IUpdateDownloader, UpdateDownloader>();
+        services.AddSingleton<IConfigService, ConfigService>();
+        services.AddSingleton<IUninstaller, Uninstaller>();
+        services.AddSingleton<IScriptExecutor, ScriptExecutor>();
+        services.AddSingleton<IProcessInvoker, ProcessInvoker>();
+        services.AddSingleton<IUpdateDownloader, UpdateDownloader>();
         services.AddSingleton<IFileLogsManager, FileLogsManager>();
         services.AddSingleton<IScriptingShellFactory, ScriptingShellFactory>();
 
         if (OperatingSystem.IsWindows())
         {
-            services.AddScoped<IAppLauncher, AppLauncherWin>();
+            services.AddSingleton<IAppLauncher, AppLauncherWin>();
             services.AddSingleton<IUpdater, UpdaterWin>();
             services.AddSingleton<IDeviceInformationService, DeviceInfoGeneratorWin>();
             services.AddSingleton<IElevationDetector, ElevationDetectorWin>();
         }
         else if (OperatingSystem.IsLinux())
         {
-            services.AddScoped<IAppLauncher, AppLauncherLinux>();
+            services.AddSingleton<IAppLauncher, AppLauncherLinux>();
             services.AddSingleton<IUpdater, UpdaterLinux>();
             services.AddSingleton<IDeviceInformationService, DeviceInfoGeneratorLinux>();
             services.AddSingleton<IElevationDetector, ElevationDetectorLinux>();
         }
         else if (OperatingSystem.IsMacOS())
         {
-            services.AddScoped<IAppLauncher, AppLauncherMac>();
+            services.AddSingleton<IAppLauncher, AppLauncherMac>();
             services.AddSingleton<IUpdater, UpdaterMac>();
             services.AddSingleton<IDeviceInformationService, DeviceInfoGeneratorMac>();
         }

--- a/Agent/Services/Linux/AppLauncherLinux.cs
+++ b/Agent/Services/Linux/AppLauncherLinux.cs
@@ -175,7 +175,7 @@ public class AppLauncherLinux : IAppLauncher
         }
     }
 
-    public async Task RestartScreenCaster(List<string> viewerIDs, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1)
+    public async Task RestartScreenCaster(string[] viewerIds, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1)
     {
         try
         {
@@ -192,7 +192,7 @@ public class AppLauncherLinux : IAppLauncher
         }
         catch (Exception ex)
         {
-            await hubConnection.SendAsync("SendConnectionFailedToViewers", viewerIDs);
+            await hubConnection.SendAsync("SendConnectionFailedToViewers", viewerIds);
             _logger.LogError(ex, "Error while restarting screen caster.");
             throw;
         }

--- a/Agent/Services/MacOS/AppLauncherMac.cs
+++ b/Agent/Services/MacOS/AppLauncherMac.cs
@@ -19,7 +19,7 @@ public class AppLauncherMac : IAppLauncher
         await hubConnection.SendAsync("DisplayMessage", "Feature under development.", "Feature is under development.", "bg-warning", userConnectionId);
     }
 
-    public async Task RestartScreenCaster(List<string> viewerIDs, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1)
+    public async Task RestartScreenCaster(string[] viewerIds, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1)
     {
         await hubConnection.SendAsync("DisplayMessage", "Feature under development.", "Feature is under development.", "bg-warning", userConnectionId);
     }

--- a/Agent/Services/Windows/AppLauncherWin.cs
+++ b/Agent/Services/Windows/AppLauncherWin.cs
@@ -159,7 +159,7 @@ public class AppLauncherWin : IAppLauncher
                 userConnectionId);
         }
     }
-    public async Task RestartScreenCaster(List<string> viewerIDs, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1)
+    public async Task RestartScreenCaster(string[] viewerIds, string sessionId, string accessKey, string userConnectionId, string requesterName, string orgName, string orgId, HubConnection hubConnection, int targetSessionID = -1)
     {
         try
         {
@@ -179,7 +179,7 @@ public class AppLauncherWin : IAppLauncher
                         $" --org-id \"{orgId}\"" +
                         $" --session-id \"{sessionId}\"" +
                         $" --access-key \"{accessKey}\"" +
-                        $" --viewers {string.Join(",", viewerIDs)}",
+                        $" --viewers {string.Join(",", viewerIds)}",
 
                     targetSessionId: targetSessionID,
                     forceConsoleSession: Shlwapi.IsOS(OsType.OS_ANYSERVER) && targetSessionID == -1,
@@ -190,7 +190,7 @@ public class AppLauncherWin : IAppLauncher
                 if (!result)
                 {
                     _logger.LogWarning("Failed to relaunch screen caster.");
-                    await hubConnection.SendAsync("SendConnectionFailedToViewers", viewerIDs);
+                    await hubConnection.SendAsync("SendConnectionFailedToViewers", viewerIds);
                     await hubConnection.SendAsync("DisplayMessage",
                         "Remote control failed to start on target device.",
                         "Failed to start remote control.",
@@ -209,12 +209,12 @@ public class AppLauncherWin : IAppLauncher
                     $" --org-id \"{orgId}\"" +
                     $" --session-id \"{sessionId}\"" +
                     $" --access-key \"{accessKey}\"" +
-                    $" --viewers {string.Join(",", viewerIDs)}");
+                    $" --viewers {string.Join(",", viewerIds)}");
             }
         }
         catch (Exception ex)
         {
-            await hubConnection.SendAsync("SendConnectionFailedToViewers", viewerIDs);
+            await hubConnection.SendAsync("SendConnectionFailedToViewers", viewerIds);
             _logger.LogError(ex, "Error while restarting screen caster.");
             throw;
         }

--- a/Server/API/AgentUpdateController.cs
+++ b/Server/API/AgentUpdateController.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Remotely.Server.Hubs;
 using Remotely.Server.RateLimiting;
 using Remotely.Server.Services;
+using Remotely.Shared.Interfaces;
 using System;
 using System.IO;
 using System.Linq;
@@ -18,7 +19,7 @@ namespace Remotely.Server.API;
 [ApiController]
 public class AgentUpdateController : ControllerBase
 {
-    private readonly IHubContext<AgentHub> _agentHubContext;
+    private readonly IHubContext<AgentHub, IAgentHubClient> _agentHubContext;
     private readonly ILogger<AgentUpdateController> _logger;
     private readonly IApplicationConfig _appConfig;
     private readonly IWebHostEnvironment _hostEnv;
@@ -27,7 +28,7 @@ public class AgentUpdateController : ControllerBase
     public AgentUpdateController(IWebHostEnvironment hostingEnv,
         IApplicationConfig appConfig,
         IAgentHubSessionCache serviceSessionCache,
-        IHubContext<AgentHub> agentHubContext,
+        IHubContext<AgentHub, IAgentHubClient> agentHubContext,
         ILogger<AgentUpdateController> logger)
     {
         _hostEnv = hostingEnv;
@@ -111,8 +112,7 @@ public class AgentUpdateController : ControllerBase
             
             var bannedDevices = _serviceSessionCache.GetAllDevices().Where(x => x.PublicIP == deviceIp);
             var connectionIds = _serviceSessionCache.GetConnectionIdsByDeviceIds(bannedDevices.Select(x => x.ID));
-
-            await _agentHubContext.Clients.Clients(connectionIds).SendAsync("UninstallAgent");
+            await _agentHubContext.Clients.Clients(connectionIds).UninstallAgent();
 
             return true;
         }

--- a/Server/API/RemoteControlController.cs
+++ b/Server/API/RemoteControlController.cs
@@ -14,6 +14,7 @@ using Immense.RemoteControl.Shared.Helpers;
 using Microsoft.Extensions.Logging;
 using Remotely.Server.Extensions;
 using Remotely.Shared.Entities;
+using Remotely.Shared.Interfaces;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -23,7 +24,7 @@ namespace Remotely.Server.API;
 [ApiController]
 public class RemoteControlController : ControllerBase
 {
-    private readonly IHubContext<AgentHub> _serviceHub;
+    private readonly IHubContext<AgentHub, IAgentHubClient> _agentHub;
     private readonly IRemoteControlSessionCache _remoteControlSessionCache;
     private readonly IAgentHubSessionCache _serviceSessionCache;
     private readonly IApplicationConfig _appConfig;
@@ -37,7 +38,7 @@ public class RemoteControlController : ControllerBase
         SignInManager<RemotelyUser> signInManager,
         IDataService dataService,
         IRemoteControlSessionCache remoteControlSessionCache,
-        IHubContext<AgentHub> serviceHub,
+        IHubContext<AgentHub, IAgentHubClient> agentHub,
         IAgentHubSessionCache serviceSessionCache,
         IOtpProvider otpProvider,
         IHubEventHandler hubEvents,
@@ -45,7 +46,7 @@ public class RemoteControlController : ControllerBase
         ILogger<RemoteControlController> logger)
     {
         _dataService = dataService;
-        _serviceHub = serviceHub;
+        _agentHub = agentHub;
         _remoteControlSessionCache = remoteControlSessionCache;
         _serviceSessionCache = serviceSessionCache;
         _appConfig = appConfig;
@@ -179,7 +180,7 @@ public class RemoteControlController : ControllerBase
             return BadRequest("Failed to resolve organization name.");
         }
 
-        await _serviceHub.Clients.Client(serviceConnectionId).SendAsync("RemoteControl", 
+        await _agentHub.Clients.Client(serviceConnectionId).RemoteControl(
             sessionId,
             accessKey,
             HttpContext.Connection.Id,

--- a/Server/Pages/ServerConfig.razor.cs
+++ b/Server/Pages/ServerConfig.razor.cs
@@ -11,6 +11,7 @@ using Remotely.Server.Hubs;
 using Remotely.Server.Services;
 using Remotely.Shared.Entities;
 using Remotely.Shared.Enums;
+using Remotely.Shared.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -144,7 +145,7 @@ public partial class ServerConfig : AuthComponentBase
 
 
     [Inject]
-    private IHubContext<AgentHub> AgentHubContext { get; init; } = null!;
+    private IHubContext<AgentHub, IAgentHubClient> AgentHubContext { get; init; } = null!;
 
     [Inject]
     private IConfiguration Configuration { get; init; } = null!;
@@ -468,7 +469,7 @@ public partial class ServerConfig : AuthComponentBase
 
         var agentConnections = ServiceSessionCache.GetConnectionIdsByDeviceIds(OutdatedDevices);
 
-        await AgentHubContext.Clients.Clients(agentConnections).SendAsync("ReinstallAgent");
+        await AgentHubContext.Clients.Clients(agentConnections).ReinstallAgent();
         ToastService.ShowToast("Update command sent.");
     }
 }

--- a/Shared/Interfaces/IAgentHubClient.cs
+++ b/Shared/Interfaces/IAgentHubClient.cs
@@ -1,0 +1,92 @@
+﻿using Remotely.Shared.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Remotely.Shared.Interfaces;
+public interface IAgentHubClient
+{
+    Task ChangeWindowsSession(
+        string viewerConnectionId,
+        string sessionId,
+        string accessKey,
+        string userConnectionId,
+        string requesterName,
+        string orgName,
+        string orgId,
+        int targetSessionId);
+
+    Task SendChatMessage(
+        string senderName, 
+        string message, 
+        string orgName, 
+        string orgId, 
+        bool disconnected, 
+        string senderConnectionId);
+
+    Task InvokeCtrlAltDel();
+
+    Task DeleteLogs();
+
+    Task ExecuteCommand(
+        ScriptingShell shell, 
+        string command, 
+        string authToken, 
+        string senderUsername, 
+        string senderConnectionId);
+
+    Task ExecuteCommandFromApi(ScriptingShell shell,
+            string authToken,
+            string requestID,
+            string command,
+            string senderUsername);
+
+    Task GetLogs(string senderConnectionId);
+
+    Task GetPowerShellCompletions(
+        string inputText, 
+        int currentIndex, 
+        CompletionIntent intent, 
+        bool? forward, 
+        string senderConnectionId);
+
+    Task ReinstallAgent();
+
+    Task UninstallAgent();
+
+    Task RemoteControl(
+        Guid sessionId, 
+        string accessKey, 
+        string userConnectionId, 
+        string requesterName, 
+        string orgName, 
+        string orgId);
+
+    Task RestartScreenCaster(
+        string[] viewerIds, 
+        string sessionId, 
+        string accessKey, 
+        string userConnectionId, 
+        string requesterName, 
+        string orgName, 
+        string orgId);
+
+    Task RunScript(
+        Guid savedScriptId, 
+        int scriptRunId, 
+        string initiator, 
+        ScriptInputType scriptInputType, 
+        string authToken);
+
+    Task TransferFileFromBrowserToAgent(
+        string transferId, 
+        string[] fileIds, 
+        string requesterId, 
+        string expiringToken);
+
+    Task TriggerHeartbeat();
+
+    Task WakeDevice(string macAddress);
+}

--- a/Tests/Server.Tests/AgentHubTests.cs
+++ b/Tests/Server.Tests/AgentHubTests.cs
@@ -7,17 +7,12 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Remotely.Server.Hubs;
-using Remotely.Server.Models;
 using Remotely.Server.Services;
-using Remotely.Shared.Dtos;
-using Remotely.Shared.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Remotely.Shared.Interfaces;
 
 namespace Remotely.Tests;
 
@@ -52,14 +47,14 @@ public class AgentHubTests
             expiringTokenService.Object,
             logger.Object);
 
-        var hubClients = new Mock<IHubCallerClients>();
-        var caller = new Mock<ISingleClientProxy>();
+        var hubClients = new Mock<IHubCallerClients<IAgentHubClient>>();
+        var caller = new Mock<IAgentHubClient>();
         hubClients.Setup(x => x.Caller).Returns(caller.Object);
         hub.Clients = hubClients.Object;
 
         Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1.ToDto()));
         hubClients.Verify(x => x.Caller, Times.Once);
-        caller.Verify(x => x.SendCoreAsync("UninstallAgent", It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        caller.Verify(x => x.UninstallAgent(), Times.Once);
     }
 
     // TODO: Checking of device ban should be pulled out into
@@ -89,14 +84,14 @@ public class AgentHubTests
             expiringTokenService.Object,
             logger.Object);
 
-        var hubClients = new Mock<IHubCallerClients>();
-        var caller = new Mock<ISingleClientProxy>();
+        var hubClients = new Mock<IHubCallerClients<IAgentHubClient>>();
+        var caller = new Mock<IAgentHubClient>();
         hubClients.Setup(x => x.Caller).Returns(caller.Object);
         hub.Clients = hubClients.Object;
 
         Assert.IsFalse(await hub.DeviceCameOnline(_testData.Org1Device1.ToDto()));
         hubClients.Verify(x => x.Caller, Times.Once);
-        caller.Verify(x => x.SendCoreAsync("UninstallAgent", It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        caller.Verify(x => x.UninstallAgent(), Times.Once);
     }
 
     [TestCleanup]

--- a/Tests/Server.Tests/CircuitConnectionTests.cs
+++ b/Tests/Server.Tests/CircuitConnectionTests.cs
@@ -12,6 +12,7 @@ using Remotely.Server.Services;
 using Remotely.Server.Tests.Mocks;
 using Remotely.Shared.Dtos;
 using Remotely.Shared.Extensions;
+using Remotely.Shared.Interfaces;
 using Remotely.Shared.Models;
 using Remotely.Tests;
 using System;
@@ -30,7 +31,7 @@ public class CircuitConnectionTests
     private IDataService _dataService;
     private Mock<IAuthService> _authService;
     private Mock<IClientAppState> _clientAppState;
-    private HubContextFixture<AgentHub> _agentHubContextFixture;
+    private HubContextFixture<AgentHub, IAgentHubClient> _agentHubContextFixture;
     private Mock<IApplicationConfig> _appConfig;
     private Mock<ICircuitManager> _circuitManager;
     private Mock<IToastService> _toastService;
@@ -50,7 +51,7 @@ public class CircuitConnectionTests
         _dataService = IoCActivator.ServiceProvider.GetRequiredService<IDataService>();
         _authService = new Mock<IAuthService>();
         _clientAppState = new Mock<IClientAppState>();
-        _agentHubContextFixture = new HubContextFixture<AgentHub>();
+        _agentHubContextFixture = new HubContextFixture<AgentHub, IAgentHubClient>();
         _appConfig = new Mock<IApplicationConfig>();
         _circuitManager = new Mock<ICircuitManager>();
         _toastService = new Mock<IToastService>();
@@ -174,11 +175,7 @@ public class CircuitConnectionTests
 
         _agentHubContextFixture.SingleClientProxyMock
             .Verify(x =>
-                x.SendCoreAsync(
-                    "WakeDevice",
-                    new object[] { macAddress },
-                    default),
-                    Times.Once);
+                x.WakeDevice(macAddress), Times.Once);
 
         _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
         _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
@@ -247,11 +244,7 @@ public class CircuitConnectionTests
 
         _agentHubContextFixture.SingleClientProxyMock
             .Verify(x =>
-                x.SendCoreAsync(
-                    "WakeDevice",
-                    new object[] { macAddress },
-                    default),
-                    Times.Once);
+                x.WakeDevice(macAddress), Times.Once);
 
         _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
         _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
@@ -387,11 +380,7 @@ public class CircuitConnectionTests
 
         _agentHubContextFixture.SingleClientProxyMock
             .Verify(x =>
-                x.SendCoreAsync(
-                    "WakeDevice",
-                    new object[] { macAddress },
-                    default),
-                    Times.Once);
+                x.WakeDevice(macAddress), Times.Once);
 
         _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
         _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();
@@ -468,11 +457,7 @@ public class CircuitConnectionTests
 
         _agentHubContextFixture.SingleClientProxyMock
             .Verify(x =>
-                x.SendCoreAsync(
-                    "WakeDevice",
-                    new object[] { macAddress },
-                    default),
-                    Times.Once);
+                x.WakeDevice(macAddress), Times.Once);
 
         _agentHubContextFixture.SingleClientProxyMock.VerifyNoOtherCalls();
         _agentHubContextFixture.HubContextMock.VerifyNoOtherCalls();

--- a/Tests/Server.Tests/Mocks/HubContextFixture.cs
+++ b/Tests/Server.Tests/Mocks/HubContextFixture.cs
@@ -9,17 +9,19 @@ using System.Threading.Tasks;
 
 namespace Remotely.Server.Tests.Mocks;
 
-public class HubContextFixture<T>
-    where T : Hub
+public class HubContextFixture<THub, THubClient>
+    where THub : Hub<THubClient>
+    where THubClient : class
 {
     public HubContextFixture()
     { 
-        HubContextMock = new Mock<IHubContext<T>>();
-        HubClientsMock = new Mock<IHubClients>();
+        
+        HubContextMock = new Mock<IHubContext<THub, THubClient>>();
+        HubClientsMock = new Mock<IHubClients<THubClient>>();
         GroupManagerMock = new Mock<IGroupManager>();
-        SingleClientProxyMock = new Mock<ISingleClientProxy>();
-        ClientProxyMock = new Mock<IClientProxy>();
-
+        SingleClientProxyMock = new Mock<THubClient>();
+        ClientProxyMock = new Mock<THubClient>();
+        
         HubContextMock
             .Setup(x => x.Clients)
             .Returns(HubClientsMock.Object);
@@ -37,9 +39,9 @@ public class HubContextFixture<T>
             .Returns(ClientProxyMock.Object);
     }
 
-    public Mock<IHubContext<T>> HubContextMock { get; }
-    public Mock<IHubClients> HubClientsMock { get; }
+    public Mock<IHubContext<THub, THubClient>> HubContextMock { get; }
+    public Mock<IHubClients<THubClient>> HubClientsMock { get; }
     public Mock<IGroupManager> GroupManagerMock { get; }
-    public Mock<ISingleClientProxy> SingleClientProxyMock { get; }
-    public Mock<IClientProxy> ClientProxyMock { get; }
+    public Mock<THubClient> SingleClientProxyMock { get; }
+    public Mock<THubClient> ClientProxyMock { get; }
 }


### PR DESCRIPTION
Changes:
- Convert AgentHub to use strongly-typed clients.
- Changed scoped services to singletons in Agent, since they are effectively singletons in a desktop app.
  - Scoped is really for web apps, where the scope is created for each request.
- If agent is running un-elevated on Windows, `CpuUtilizationSampler` will now skip processes in session 0.
  - These will throw when unelevated (e.g. when debugging).

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
