### PR TITLE
Lock Moq version at 4.18.4.

### DIFF
--- a/Tests/LoadTester/LoadTester.csproj
+++ b/Tests/LoadTester/LoadTester.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Server.Tests/Server.Tests.csproj
+++ b/Tests/Server.Tests/Server.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR locks the version of Moq at 4.18.4.  This is the last version before the SponsorLink debacle happened.  We'll probably switch to NSubstitute later.

More info here:  https://github.com/moq/moq/issues/1372


---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
