### PR TITLE
Fix remote control at X11 greeter.

### DIFF
--- a/Shared/Extensions/IEnumerableExtensions.cs
+++ b/Shared/Extensions/IEnumerableExtensions.cs
@@ -16,4 +16,18 @@ public static class IEnumerableExtensions
             await Task.Yield();
         }
     }
+
+    public static int IndexWhere<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        var index = 0;
+        foreach (var item in source)
+        {
+            if (predicate(item))
+            {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }   
 }


### PR DESCRIPTION
When no users are logged in, and the console is at the greeter/login screen, the agent wasn't correctly determining the X display and authority file from the Xorg process.  This fixes that.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
