### PR TITLE
Add platform guards for Windows APIs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -114,6 +114,7 @@ dotnet_style_qualification_for_field = false:silent
 
 # IDE0130: Namespace does not match folder structure
 dotnet_diagnostic.IDE0130.severity = error
+dotnet_diagnostic.CA1416.severity = error
 
 [*.cs]
 csharp_indent_labels = one_less_than_current
@@ -174,3 +175,4 @@ dotnet_diagnostic.CS8602.severity = error
 
 # CS8631: The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.
 dotnet_diagnostic.CS8631.severity = error
+csharp_style_prefer_primary_constructors = true:suggestion

--- a/Desktop.Win/Program.cs
+++ b/Desktop.Win/Program.cs
@@ -14,6 +14,7 @@ using Immense.RemoteControl.Desktop.UI.Services;
 using Avalonia;
 using Immense.RemoteControl.Desktop.UI;
 using Desktop.Shared.Services;
+using System.Runtime.Versioning;
 
 namespace Remotely.Desktop.Win;
 
@@ -26,6 +27,8 @@ public class Program
             .WithInterFont()
             .LogToTrace();
 
+
+    [SupportedOSPlatform("windows")]
     public static async Task Main(string[] args)
     {
         var version = AppVersionHelper.GetAppVersion();


### PR DESCRIPTION
The Windows project no longer explicitly targets Windows, so platform guards are needed to prevent warnings.  I also set this warning to be treated as an error.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
