### PR TITLE
Fix device filtering.

### DIFF
--- a/Server/Components/Devices/DevicesFrame.razor
+++ b/Server/Components/Devices/DevicesFrame.razor
@@ -86,7 +86,7 @@
         </div>
     </div>
     <div id="deviceListDiv" class="p-2 mb-5">
-        @foreach (var device in _devicesForPage)
+        @foreach (var device in DisplayedDevices)
         {
             <CascadingValue Value="this">
                 <DeviceCard @key="device.ID" Device="device" />

--- a/Shared/Entities/Device.cs
+++ b/Shared/Entities/Device.cs
@@ -50,7 +50,6 @@ public class Device
     [Display(Name = "Last Online")]
     public DateTimeOffset LastOnline { get; set; }
 
-    [Sortable]
     [Display(Name = "MAC Addresses")]
     public string[] MacAddresses { get; set; } = Array.Empty<string>();
 


### PR DESCRIPTION
Filtering/sorting was taking an extra render to show.   This fixes that.

I also added tracking of state that affects sorting/filtering to reduce the amount of work needed between renders.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
