### PR TITLE
Reconnect after Windows logoff or reboot.

### DIFF
--- a/Agent/Services/AgentHubConnection.cs
+++ b/Agent/Services/AgentHubConnection.cs
@@ -180,6 +180,7 @@ public class AgentHubConnection : IAgentHubConnection, IDisposable
                 _heartbeatTimer.Start();
 
                 await _hubConnection.SendAsync("CheckForPendingSriptRuns");
+                await _hubConnection.SendAsync("CheckForPendingRemoteControlSessions");
 
                 break;
             }
@@ -377,13 +378,13 @@ public class AgentHubConnection : IAgentHubConnection, IDisposable
                 return;
             }
             await _appLauncher.RestartScreenCaster(
-                viewerIds, 
-                sessionId, 
-                accessKey, 
-                userConnectionId, 
-                requesterName, 
-                orgName, 
-                orgId, 
+                viewerIds,
+                sessionId,
+                accessKey,
+                userConnectionId,
+                requesterName,
+                orgName,
+                orgId,
                 _hubConnection);
         }
         catch (Exception ex)
@@ -393,10 +394,10 @@ public class AgentHubConnection : IAgentHubConnection, IDisposable
     }
 
     public async Task RunScript(
-        Guid savedScriptId, 
-        int scriptRunId, 
-        string initiator, 
-        ScriptInputType scriptInputType, 
+        Guid savedScriptId,
+        int scriptRunId,
+        string initiator,
+        ScriptInputType scriptInputType,
         string authToken)
     {
         try
@@ -607,7 +608,7 @@ public class AgentHubConnection : IAgentHubConnection, IDisposable
 
         // TODO: Replace all these parameters with a single DTO per method.
         _hubConnection.On<string, string, string, string, string, string, string, int>(
-            nameof(ChangeWindowsSession), 
+            nameof(ChangeWindowsSession),
             ChangeWindowsSession);
 
         _hubConnection.On<string, string, string, string, bool, string>(nameof(SendChatMessage), SendChatMessage);
@@ -619,7 +620,7 @@ public class AgentHubConnection : IAgentHubConnection, IDisposable
         _hubConnection.On<ScriptingShell, string, string, string, string>(nameof(ExecuteCommand), ExecuteCommand);
 
         _hubConnection.On<ScriptingShell, string, string, string, string>(nameof(ExecuteCommandFromApi), ExecuteCommandFromApi);
-      
+
         _hubConnection.On<string>(nameof(GetLogs), GetLogs);
 
         _hubConnection.On<string, int, CompletionIntent, bool?, string>(nameof(GetPowerShellCompletions), GetPowerShellCompletions);
@@ -631,13 +632,13 @@ public class AgentHubConnection : IAgentHubConnection, IDisposable
         _hubConnection.On<Guid, string, string, string, string, string>(nameof(RemoteControl), RemoteControl);
 
         _hubConnection.On<string[], string, string, string, string, string, string>(
-            nameof(RestartScreenCaster), 
+            nameof(RestartScreenCaster),
             RestartScreenCaster);
 
         _hubConnection.On<Guid, int, string, ScriptInputType, string>(nameof(RunScript), RunScript);
 
         _hubConnection.On<string, string[], string, string>(
-            nameof(TransferFileFromBrowserToAgent), 
+            nameof(TransferFileFromBrowserToAgent),
             TransferFileFromBrowserToAgent);
 
         _hubConnection.On(nameof(TriggerHeartbeat), TriggerHeartbeat);

--- a/Tests/Server.Tests/AgentHubTests.cs
+++ b/Tests/Server.Tests/AgentHubTests.cs
@@ -1,5 +1,6 @@
-﻿using Remotely.Shared.Extensions;
-using Immense.RemoteControl.Server.Hubs;
+﻿using Immense.RemoteControl.Server.Hubs;
+using Immense.RemoteControl.Server.Services;
+using Immense.SimpleMessenger;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,12 +9,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Remotely.Server.Hubs;
 using Remotely.Server.Services;
+using Remotely.Shared.Extensions;
+using Remotely.Shared.Interfaces;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using Remotely.Shared.Interfaces;
-using Immense.SimpleMessenger;
 
 namespace Remotely.Server.Tests;
 
@@ -35,6 +36,7 @@ public class AgentHubTests
         var viewerHub = new Mock<IHubContext<ViewerHub>>();
         var expiringTokenService = new Mock<IExpiringTokenService>();
         var serviceSessionCache = new Mock<IAgentHubSessionCache>();
+        var remoteControlSessions = new Mock<IRemoteControlSessionCache>();
         var messenger = new Mock<IMessenger>();
         var logger = new Mock<ILogger<AgentHub>>();
 
@@ -47,6 +49,7 @@ public class AgentHubTests
             viewerHub.Object,
             circuitManager.Object,
             expiringTokenService.Object,
+            remoteControlSessions.Object,
             messenger.Object,
             logger.Object);
 
@@ -74,6 +77,7 @@ public class AgentHubTests
         var viewerHub = new Mock<IHubContext<ViewerHub>>();
         var expiringTokenService = new Mock<IExpiringTokenService>();
         var serviceSessionCache = new Mock<IAgentHubSessionCache>();
+        var remoteControlSessions = new Mock<IRemoteControlSessionCache>();
         var messenger = new Mock<IMessenger>();
         var logger = new Mock<ILogger<AgentHub>>();
 
@@ -86,6 +90,7 @@ public class AgentHubTests
             viewerHub.Object,
             circuitManager.Object,
             expiringTokenService.Object,
+            remoteControlSessions.Object,
             messenger.Object,
             logger.Object);
 


### PR DESCRIPTION
Requires https://github.com/immense/RemoteControl/pull/40.

This PR lets a remote control session reconnect after a Windows using logs off or after Windows is rebooted.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
