### PR TITLE
Fix installer main window.

### DIFF
--- a/Agent.Installer.Win/MainWindow.xaml
+++ b/Agent.Installer.Win/MainWindow.xaml
@@ -7,7 +7,6 @@
         xmlns:local="clr-namespace:Remotely.Agent.Installer.Win"
         mc:Ignorable="d"
         ResizeMode="CanResizeWithGrip"
-        AllowsTransparency="True"
         MouseLeftButtonDown="Window_MouseLeftButtonDown"
         Loaded="Window_Loaded"
         WindowStartupLocation="CenterScreen"


### PR DESCRIPTION
During earlier refactoring, we put the default window chrome (titlebar, etc.) back into all windows.  The `AllowsTransparency` property on the installer's main window was no longer compatible after this change and was causing the app the crash.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
