### PR TITLE
Correct sqlite db file path in docker-compose.yml

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       # the network config, you must update this value as well.
       - Remotely_ApplicationOptions__DockerGateway=172.28.0.1
       # This path shouldn't be changed.  It points to the Docker volume.
-      - Remotely_ConnectionStrings__SQLite=Data Source=/app/AppData/Remotely.db
+      - Remotely_ConnectionStrings__SQLite=Data Source=/app/Remotely.db
       # If using SQL Server, change the connection string to point to your SQL Server instance.
       - Remotely_ConnectionStrings__SQLServer=Server=(localdb)\\mssqllocaldb;Database=Remotely-Server-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true
       # If using PostgreSQL, change the connection string to point to your PostgreSQL instance.


### PR DESCRIPTION
The `Remotely.db` file is not in `/app/AppData` but rather in `/app/`

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
