### PR TITLE
Scope loader messages to the circuit connection.

### DIFF
--- a/Server/Hubs/CircuitConnection.cs
+++ b/Server/Hubs/CircuitConnection.cs
@@ -261,7 +261,7 @@ public class CircuitConnection : CircuitHandler, ICircuitConnection
                 "There are already the maximum amount of active remote control sessions for your organization.",
                 "Max number of concurrent sessions reached.",
                 "bg-warning");
-
+            
             await _messenger.Send(message, ConnectionId);
 
             return Result.Fail<RemoteControlSessionEx>("Max number of concurrent sessions reached.");

--- a/Server/Services/LoaderService.cs
+++ b/Server/Services/LoaderService.cs
@@ -1,8 +1,7 @@
 ﻿using Immense.RemoteControl.Shared.Primitives;
 using Immense.SimpleMessenger;
+using Remotely.Server.Hubs;
 using Remotely.Server.Models.Messages;
-using System;
-using System.Threading.Tasks;
 
 namespace Remotely.Server.Services;
 
@@ -12,23 +11,16 @@ public interface ILoaderService
     void HideLoader();
 }
 
-public class LoaderService : ILoaderService
+public class LoaderService(IMessenger _messenger, ICircuitConnection _circuitConnection) : ILoaderService
 {
-    private readonly IMessenger _messenger;
-
-    public LoaderService(IMessenger messenger)
-    {
-        _messenger = messenger;
-    }
-
     public async Task<IDisposable> ShowLoader(string statusMessage)
     {
-        await _messenger.Send(new ShowLoaderMessage(true, statusMessage));
+        await _messenger.Send(new ShowLoaderMessage(true, statusMessage), _circuitConnection.ConnectionId);
         return new CallbackDisposable(HideLoader);
     }
 
     public void HideLoader()
     {
-        _messenger.Send(new ShowLoaderMessage(false, string.Empty));
+        _messenger.Send(new ShowLoaderMessage(false, string.Empty), _circuitConnection.ConnectionId);
     }
 }


### PR DESCRIPTION
Scope loader messages to the circuit connection.  This keeps it from appearing in other tabs, since the `IMessenger` is singleton.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
