### PR TITLE
Update default logging minimum levels to reduce spam.

### DIFF
--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -6,15 +6,16 @@
   },
   "Logging": {
     "LogLevel": {
+      "Default": "Information",
       "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
-      "Default": "Information"
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
         "System": "Warning"
       }
     }

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - ASPNETCORE_HTTP_PORTS=5000
       # Other ASP.NET Core configurations can be overridden here, such as Logging.
       # See https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0
+      - Serilog__MinimumLevel__Override__Microsoft.AspNetCore=Warning
+      - Serilog__MinimumLevel__Override__System=Warning
 
       # Values for DbProvider are SQLite, SQLServer, and PostgreSQL.
       - Remotely_ApplicationOptions__DbProvider=SQLite


### PR DESCRIPTION
Update default logging minimum levels to reduce spam.

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
