### PR TITLE
Assortment of updates.

### DIFF
--- a/.azure-pipelines/Release Build.yml
+++ b/.azure-pipelines/Release Build.yml
@@ -5,71 +5,71 @@ pr:
 - master
 
 jobs:
-#- job: Mac_Build
-#  displayName: Mac Build
-#  timeoutInMinutes: 360
-#  pool:
-#    vmImage: macos-latest
-#  steps:
-#  
-#  - task: InstallSSHKey@0
-#    inputs:
-#      knownHostsEntry: |
-#        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-#        github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-#        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
-#      sshKeySecureFile: 'pipelines_rsa'
-#
-#  - checkout: self
-#    submodules: recursive
-#    clean: true
-#    fetchTags: false
-#
-#  - task: PowerShell@2
-#    displayName: Add CurrentVersion Variable
-#    inputs:
-#      targetType: inline
-#      script: |
-#        $VersionString = git show -s --format=%ci $(Build.SourceVersion)
-#        $VersionDate = [DateTimeOffset]::Parse($VersionString)
-#        $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
-#
-#        [System.Console]::WriteLine("##vso[task.setvariable variable=CurrentVersion]$CurrentVersion")
-#
-#        Write-Host "Setting current version to $CurrentVersion."
-#
-#  - task: UseDotNet@2
-#    displayName: Use .NET SDK
-#    inputs:
-#      version: 8.x
-#
-#  - task: DotNetCoreCLI@2
-#    displayName: dotnet publish x64
-#    inputs:
-#      command: publish
-#      publishWebProjects: false
-#      projects: '**/Agent.csproj'
-#      arguments: -c $(BuildConfiguration) -r osx-x64 -o "$(Build.SourcesDirectory)/Agent/bin/publish" /p:Version=$(CurrentVersion) /p:FileVersion=$(CurrentVersion)
-#      zipAfterPublish: false
-#      modifyOutputPath: false
-#
-#  - task: PowerShell@2
-#    displayName: PowerShell Script
-#    inputs:
-#      targetType: inline
-#      script: |
-#        Compress-Archive -Path "$(Build.SourcesDirectory)/Agent/bin/publish/*" -DestinationPath "$(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip" -Force
-#
-#  - task: PublishPipelineArtifact@1
-#    displayName: Publish macOS x64 Agent
-#    inputs:
-#      path: $(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip
-#      artifactName: Mac-x64-Agent
+- job: Mac_Build
+  displayName: Mac Build
+  timeoutInMinutes: 360
+  pool:
+    vmImage: macos-latest
+  steps:
+  
+  - task: InstallSSHKey@0
+    inputs:
+      knownHostsEntry: |
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+        github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+      sshKeySecureFile: 'pipelines_rsa'
+
+  - checkout: self
+    submodules: recursive
+    clean: true
+    fetchTags: false
+
+  - task: PowerShell@2
+    displayName: Add CurrentVersion Variable
+    inputs:
+      targetType: inline
+      script: |
+        $VersionString = git show -s --format=%ci $(Build.SourceVersion)
+        $VersionDate = [DateTimeOffset]::Parse($VersionString)
+        $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
+
+        [System.Console]::WriteLine("##vso[task.setvariable variable=CurrentVersion]$CurrentVersion")
+
+        Write-Host "Setting current version to $CurrentVersion."
+
+  - task: UseDotNet@2
+    displayName: Use .NET SDK
+    inputs:
+      version: 8.x
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish x64
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '**/Agent.csproj'
+      arguments: -c $(BuildConfiguration) -r osx-x64 -o "$(Build.SourcesDirectory)/Agent/bin/publish" /p:Version=$(CurrentVersion) /p:FileVersion=$(CurrentVersion)
+      zipAfterPublish: false
+      modifyOutputPath: false
+
+  - task: PowerShell@2
+    displayName: PowerShell Script
+    inputs:
+      targetType: inline
+      script: |
+        Compress-Archive -Path "$(Build.SourcesDirectory)/Agent/bin/publish/*" -DestinationPath "$(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip" -Force
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish macOS x64 Agent
+    inputs:
+      path: $(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip
+      artifactName: Mac-x64-Agent
 
 - job: Windows_Build
   displayName: Windows Build
   timeoutInMinutes: 360
-  #dependsOn: Mac_Build
+  dependsOn: Mac_Build
   pool:
     vmImage: windows-latest
 
@@ -90,11 +90,11 @@ jobs:
   - task: VisualStudioTestPlatformInstaller@1
     displayName: Visual Studio Test Platform Installer
 
-#  - task: DownloadPipelineArtifact@2
-#    displayName: Download macOS x64 Agent
-#    inputs:
-#      artifact: Mac-x64-Agent
-#      path: $(Build.SourcesDirectory)\Server\wwwroot\Content\
+  - task: DownloadPipelineArtifact@2
+    displayName: Download macOS x64 Agent
+    inputs:
+      artifact: Mac-x64-Agent
+      path: $(Build.SourcesDirectory)\Server\wwwroot\Content\
 
   - task: PowerShell@2
     displayName: Add CurrentVersion Variable

--- a/.azure-pipelines/Release Build.yml
+++ b/.azure-pipelines/Release Build.yml
@@ -8,7 +8,6 @@ jobs:
 - job: Windows_Build
   displayName: Windows Build
   timeoutInMinutes: 360
-  dependsOn: Mac_Build
   pool:
     vmImage: windows-latest
 

--- a/.azure-pipelines/Release Build.yml
+++ b/.azure-pipelines/Release Build.yml
@@ -5,67 +5,6 @@ pr:
 - master
 
 jobs:
-- job: Mac_Build
-  displayName: Mac Build
-  timeoutInMinutes: 360
-  pool:
-    vmImage: macos-latest
-  steps:
-  
-  - task: InstallSSHKey@0
-    inputs:
-      knownHostsEntry: |
-        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-        github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
-      sshKeySecureFile: 'pipelines_rsa'
-
-  - checkout: self
-    submodules: recursive
-    clean: true
-    fetchTags: false
-
-  - task: PowerShell@2
-    displayName: Add CurrentVersion Variable
-    inputs:
-      targetType: inline
-      script: |
-        $VersionString = git show -s --format=%ci $(Build.SourceVersion)
-        $VersionDate = [DateTimeOffset]::Parse($VersionString)
-        $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
-
-        [System.Console]::WriteLine("##vso[task.setvariable variable=CurrentVersion]$CurrentVersion")
-
-        Write-Host "Setting current version to $CurrentVersion."
-
-  - task: UseDotNet@2
-    displayName: Use .NET SDK
-    inputs:
-      version: 8.x
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish x64
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: '**/Agent.csproj'
-      arguments: -c $(BuildConfiguration) -r osx-x64 -o "$(Build.SourcesDirectory)/Agent/bin/publish" /p:Version=$(CurrentVersion) /p:FileVersion=$(CurrentVersion)
-      zipAfterPublish: false
-      modifyOutputPath: false
-
-  - task: PowerShell@2
-    displayName: PowerShell Script
-    inputs:
-      targetType: inline
-      script: |
-        Compress-Archive -Path "$(Build.SourcesDirectory)/Agent/bin/publish/*" -DestinationPath "$(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip" -Force
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish macOS x64 Agent
-    inputs:
-      path: $(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip
-      artifactName: Mac-x64-Agent
-
 - job: Windows_Build
   displayName: Windows Build
   timeoutInMinutes: 360
@@ -90,12 +29,6 @@ jobs:
   - task: VisualStudioTestPlatformInstaller@1
     displayName: Visual Studio Test Platform Installer
 
-  - task: DownloadPipelineArtifact@2
-    displayName: Download macOS x64 Agent
-    inputs:
-      artifact: Mac-x64-Agent
-      path: $(Build.SourcesDirectory)\Server\wwwroot\Content\
-
   - task: PowerShell@2
     displayName: Add CurrentVersion Variable
     inputs:
@@ -111,12 +44,6 @@ jobs:
 
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
-
-  - task: NuGetCommand@2
-    displayName: NuGet restore Agent.Installer.Win
-    inputs:
-      solution: Agent.Installer.Win/packages.config
-      packagesDirectory: $(Build.SourcesDirectory)\packages
 
   - task: UseDotNet@2
     displayName: Use .NET SDK

--- a/.azure-pipelines/Release Build.yml
+++ b/.azure-pipelines/Release Build.yml
@@ -5,9 +5,71 @@ pr:
 - master
 
 jobs:
-- job: Build
-  displayName: Build
+#- job: Mac_Build
+#  displayName: Mac Build
+#  timeoutInMinutes: 360
+#  pool:
+#    vmImage: macos-latest
+#  steps:
+#  
+#  - task: InstallSSHKey@0
+#    inputs:
+#      knownHostsEntry: |
+#        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+#        github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+#        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+#      sshKeySecureFile: 'pipelines_rsa'
+#
+#  - checkout: self
+#    submodules: recursive
+#    clean: true
+#    fetchTags: false
+#
+#  - task: PowerShell@2
+#    displayName: Add CurrentVersion Variable
+#    inputs:
+#      targetType: inline
+#      script: |
+#        $VersionString = git show -s --format=%ci $(Build.SourceVersion)
+#        $VersionDate = [DateTimeOffset]::Parse($VersionString)
+#        $CurrentVersion = $VersionDate.ToString("yyyy.MM.dd.HHmm")
+#
+#        [System.Console]::WriteLine("##vso[task.setvariable variable=CurrentVersion]$CurrentVersion")
+#
+#        Write-Host "Setting current version to $CurrentVersion."
+#
+#  - task: UseDotNet@2
+#    displayName: Use .NET SDK
+#    inputs:
+#      version: 8.x
+#
+#  - task: DotNetCoreCLI@2
+#    displayName: dotnet publish x64
+#    inputs:
+#      command: publish
+#      publishWebProjects: false
+#      projects: '**/Agent.csproj'
+#      arguments: -c $(BuildConfiguration) -r osx-x64 -o "$(Build.SourcesDirectory)/Agent/bin/publish" /p:Version=$(CurrentVersion) /p:FileVersion=$(CurrentVersion)
+#      zipAfterPublish: false
+#      modifyOutputPath: false
+#
+#  - task: PowerShell@2
+#    displayName: PowerShell Script
+#    inputs:
+#      targetType: inline
+#      script: |
+#        Compress-Archive -Path "$(Build.SourcesDirectory)/Agent/bin/publish/*" -DestinationPath "$(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip" -Force
+#
+#  - task: PublishPipelineArtifact@1
+#    displayName: Publish macOS x64 Agent
+#    inputs:
+#      path: $(Build.SourcesDirectory)/Agent/bin/Remotely-MacOS-x64.zip
+#      artifactName: Mac-x64-Agent
+
+- job: Windows_Build
+  displayName: Windows Build
   timeoutInMinutes: 360
+  #dependsOn: Mac_Build
   pool:
     vmImage: windows-latest
 
@@ -27,6 +89,12 @@ jobs:
     
   - task: VisualStudioTestPlatformInstaller@1
     displayName: Visual Studio Test Platform Installer
+
+#  - task: DownloadPipelineArtifact@2
+#    displayName: Download macOS x64 Agent
+#    inputs:
+#      artifact: Mac-x64-Agent
+#      path: $(Build.SourcesDirectory)\Server\wwwroot\Content\
 
   - task: PowerShell@2
     displayName: Add CurrentVersion Variable

--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,4 @@ Server.Installer/Properties/launchSettings.json
 !/.vscode/launch.json
 !/.vscode/tasks.json
 /Server/appsettings.Development.json
+/Server/AppData

--- a/Agent.Installer.Win/ViewModels/MainWindowViewModel.cs
+++ b/Agent.Installer.Win/ViewModels/MainWindowViewModel.cs
@@ -317,7 +317,7 @@ public class MainWindowViewModel : ViewModelBase
             (serverUri.Scheme != Uri.UriSchemeHttp && serverUri.Scheme != Uri.UriSchemeHttps))
         {
             Logger.Write("ServerUrl is not valid.");
-            MessageBoxEx.Show("Server URL must be a valid Uri (e.g. https://app.remotely.one).", "Invalid Server URL", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBoxEx.Show("Server URL must be a valid Uri (e.g. https://app.example.com).", "Invalid Server URL", MessageBoxButton.OK, MessageBoxImage.Error);
             return false;
         }
 

--- a/Agent/Agent.csproj
+++ b/Agent/Agent.csproj
@@ -23,18 +23,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.2" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
-    <PackageReference Include="Microsoft.WSMan.Management" Version="7.4.1" />
-    <PackageReference Include="Microsoft.WSMan.Runtime" Version="7.4.1" />
-    <PackageReference Include="System.Management.Automation" Version="7.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.2" />
+    <PackageReference Include="Microsoft.WSMan.Management" Version="7.4.2" />
+    <PackageReference Include="Microsoft.WSMan.Runtime" Version="7.4.2" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.2" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
   </ItemGroup>
 

--- a/Agent/Agent.csproj
+++ b/Agent/Agent.csproj
@@ -11,7 +11,6 @@
     <Product>Remotely Agent</Product>
     <Company>Immense Networks</Company>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageProjectUrl>https://remotely.one</PackageProjectUrl>
     <Platforms>AnyCPU;x86;x64</Platforms>
     <AssemblyName>Remotely_Agent</AssemblyName>
     <RootNamespace>Remotely.Agent</RootNamespace>

--- a/Agent/Program.cs
+++ b/Agent/Program.cs
@@ -2,13 +2,10 @@
 using Microsoft.Extensions.Logging;
 using Remotely.Agent.Interfaces;
 using Remotely.Agent.Services;
-using Remotely.Shared.Enums;
 using Remotely.Shared.Utilities;
 using Remotely.Shared.Services;
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.ServiceProcess;
 using System.Threading.Tasks;
 using System.Runtime.Versioning;
 using Remotely.Agent.Services.Linux;

--- a/Desktop.Linux/Desktop.Linux.csproj
+++ b/Desktop.Linux/Desktop.Linux.csproj
@@ -30,7 +30,6 @@
     <Product>Remotely Desktop</Product>
     <Description>Desktop client for allowing your IT admin to provide remote support.</Description>
     <Copyright>Copyright © 2023 Immense Networks</Copyright>
-    <PackageProjectUrl>https://remotely.one</PackageProjectUrl>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/Desktop.Linux/Program.cs
+++ b/Desktop.Linux/Program.cs
@@ -33,7 +33,7 @@ public class Program
         var logger = new FileLogger("Remotely_Desktop", version, "Program.cs");
         var filePath = Environment.ProcessPath ?? Environment.GetCommandLineArgs().First();
         var serverUrl = Debugger.IsAttached ? "http://localhost:5000" : string.Empty;
-        var getEmbeddedResult = await EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
+        var getEmbeddedResult = EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
         if (getEmbeddedResult.IsSuccess)
         {
             serverUrl = getEmbeddedResult.Value.ServerUrl.AbsoluteUri;

--- a/Desktop.Linux/Program.cs
+++ b/Desktop.Linux/Program.cs
@@ -33,7 +33,7 @@ public class Program
         var logger = new FileLogger("Remotely_Desktop", version, "Program.cs");
         var filePath = Environment.ProcessPath ?? Environment.GetCommandLineArgs().First();
         var serverUrl = Debugger.IsAttached ? "http://localhost:5000" : string.Empty;
-        var getEmbeddedResult = EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
+        var getEmbeddedResult = EmbeddedServerDataProvider.Instance.TryGetEmbeddedData(filePath);
         if (getEmbeddedResult.IsSuccess)
         {
             serverUrl = getEmbeddedResult.Value.ServerUrl.AbsoluteUri;
@@ -46,7 +46,7 @@ public class Program
         var services = new ServiceCollection();
 
         services.AddSingleton<IOrganizationIdProvider, OrganizationIdProvider>();
-        services.AddSingleton<IEmbeddedServerDataSearcher, EmbeddedServerDataSearcher>();
+        services.AddSingleton<IEmbeddedServerDataProvider, EmbeddedServerDataProvider>();
 
         services.AddRemoteControlLinux(
             config =>

--- a/Desktop.Shared/Services/BrandingProvider.cs
+++ b/Desktop.Shared/Services/BrandingProvider.cs
@@ -13,7 +13,7 @@ namespace Desktop.Shared.Services;
 public class BrandingProvider : IBrandingProvider
 {
     private readonly IAppState _appState;
-    private readonly IEmbeddedServerDataSearcher _embeddedDataSearcher;
+    private readonly IEmbeddedServerDataProvider _embeddedDataSearcher;
     private readonly ILogger<BrandingProvider> _logger;
     private readonly IOrganizationIdProvider _orgIdProvider;
     private BrandingInfoBase? _brandingInfo;
@@ -22,7 +22,7 @@ public class BrandingProvider : IBrandingProvider
     public BrandingProvider(
         IAppState appState,
         IOrganizationIdProvider orgIdProvider,
-        IEmbeddedServerDataSearcher embeddedServerDataSearcher,
+        IEmbeddedServerDataProvider embeddedServerDataSearcher,
         ILogger<BrandingProvider> logger)
     {
         _appState = appState;

--- a/Desktop.Shared/Services/BrandingProvider.cs
+++ b/Desktop.Shared/Services/BrandingProvider.cs
@@ -85,7 +85,7 @@ public class BrandingProvider : IBrandingProvider
                     return Result.Fail<BrandingInfo>("Failed to retrieve executing file name.");
                 }
 
-                var result = await _embeddedDataSearcher.TryGetEmbeddedData(filePath);
+                var result = _embeddedDataSearcher.TryGetEmbeddedData(filePath);
 
                 if (!result.IsSuccess)
                 {

--- a/Desktop.Win/Desktop.Win.csproj
+++ b/Desktop.Win/Desktop.Win.csproj
@@ -12,7 +12,6 @@
     <Authors>Jared Goodwin</Authors>
     <Company>Immense Networks</Company>
     <Product>Remotely Desktop</Product>
-    <PackageProjectUrl>https://remotely.one</PackageProjectUrl>
     <Platforms>AnyCPU;x86;x64</Platforms>
     <StartupObject></StartupObject>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Desktop.Win/Program.cs
+++ b/Desktop.Win/Program.cs
@@ -35,7 +35,7 @@ public class Program
         var logger = new FileLogger("Remotely_Desktop", version, "Program.cs");
         var filePath = Environment.ProcessPath ?? Environment.GetCommandLineArgs().First();
         var serverUrl = Debugger.IsAttached ? "https://localhost:5001" : string.Empty;
-        var getEmbeddedResult =  EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
+        var getEmbeddedResult =  EmbeddedServerDataProvider.Instance.TryGetEmbeddedData(filePath);
         if (getEmbeddedResult.IsSuccess)
         {
             serverUrl = getEmbeddedResult.Value.ServerUrl.AbsoluteUri;
@@ -47,7 +47,7 @@ public class Program
         var services = new ServiceCollection();
 
         services.AddSingleton<IOrganizationIdProvider, OrganizationIdProvider>();
-        services.AddSingleton<IEmbeddedServerDataSearcher>(EmbeddedServerDataSearcher.Instance);
+        services.AddSingleton<IEmbeddedServerDataProvider>(EmbeddedServerDataProvider.Instance);
 
         services.AddRemoteControlWindows(
             config =>

--- a/Desktop.Win/Program.cs
+++ b/Desktop.Win/Program.cs
@@ -35,7 +35,7 @@ public class Program
         var logger = new FileLogger("Remotely_Desktop", version, "Program.cs");
         var filePath = Environment.ProcessPath ?? Environment.GetCommandLineArgs().First();
         var serverUrl = Debugger.IsAttached ? "https://localhost:5001" : string.Empty;
-        var getEmbeddedResult = await EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
+        var getEmbeddedResult =  EmbeddedServerDataSearcher.Instance.TryGetEmbeddedData(filePath);
         if (getEmbeddedResult.IsSuccess)
         {
             serverUrl = getEmbeddedResult.Value.ServerUrl.AbsoluteUri;

--- a/Remotely.slnLaunch
+++ b/Remotely.slnLaunch
@@ -1,0 +1,37 @@
+[
+  {
+    "Name": "Agent \u002B Server \u002B Desktop",
+    "Projects": [
+      {
+        "Path": "Agent\\Agent.csproj",
+        "Action": "Start",
+        "DebugTarget": "Agent"
+      },
+      {
+        "Path": "Desktop.Win\\Desktop.Win.csproj",
+        "Action": "Start",
+        "DebugTarget": "Desktop.Win"
+      },
+      {
+        "Path": "Server\\Server.csproj",
+        "Action": "Start",
+        "DebugTarget": "Server"
+      }
+    ]
+  },
+  {
+    "Name": "Agent \u002B Server",
+    "Projects": [
+      {
+        "Path": "Agent\\Agent.csproj",
+        "Action": "Start",
+        "DebugTarget": "Agent"
+      },
+      {
+        "Path": "Server\\Server.csproj",
+        "Action": "Start",
+        "DebugTarget": "Server"
+      }
+    ]
+  }
+]

--- a/Server/API/ClientDownloadsController.cs
+++ b/Server/API/ClientDownloadsController.cs
@@ -15,14 +15,14 @@ namespace Remotely.Server.API;
 public class ClientDownloadsController : ControllerBase
 {
     private readonly IDataService _dataService;
-    private readonly IEmbeddedServerDataSearcher _embeddedDataSearcher;
+    private readonly IEmbeddedServerDataProvider _embeddedDataSearcher;
     private readonly SemaphoreSlim _fileLock = new(1, 1);
     private readonly IWebHostEnvironment _hostEnv;
     private readonly ILogger<ClientDownloadsController> _logger;
 
     public ClientDownloadsController(
         IWebHostEnvironment hostEnv,
-        IEmbeddedServerDataSearcher embeddedDataSearcher,
+        IEmbeddedServerDataProvider embeddedDataSearcher,
         IDataService dataService,
         ILogger<ClientDownloadsController> logger)
     {
@@ -39,27 +39,27 @@ public class ClientDownloadsController : ControllerBase
         {
             case "WindowsDesktop-x64":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Win-x64", "Remotely_Desktop.exe");
+                    var filePath = Path.Combine("Content", "Win-x64", "Remotely_Desktop.exe");
                     return await GetDesktopFile(filePath);
                 }
             case "WindowsDesktop-x86":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Win-x86", "Remotely_Desktop.exe");
+                    var filePath = Path.Combine("Content", "Win-x86", "Remotely_Desktop.exe");
                     return await GetDesktopFile(filePath);
                 }
             case "UbuntuDesktop":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Linux-x64", "Remotely_Desktop");
+                    var filePath = Path.Combine("Content", "Linux-x64", "Remotely_Desktop");
                     return await GetDesktopFile(filePath);
                 }
             case "MacOS-x64":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "MacOS-x64", "Remotely_Desktop");
+                    var filePath = Path.Combine("Content", "MacOS-x64", "Remotely_Desktop");
                     return await GetDesktopFile(filePath);
                 }
             case "MacOS-arm64":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "MacOS-arm64", "Remotely_Desktop");
+                    var filePath = Path.Combine("Content", "MacOS-arm64", "Remotely_Desktop");
                     return await GetDesktopFile(filePath);
                 }
             default:
@@ -75,27 +75,27 @@ public class ClientDownloadsController : ControllerBase
         {
             case "WindowsDesktop-x64":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Win-x64", "Remotely_Desktop.exe");
+                    var filePath = Path.Combine("Content", "Win-x64", "Remotely_Desktop.exe");
                     return await GetDesktopFile(filePath, organizationId);
                 }
             case "WindowsDesktop-x86":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Win-x86", "Remotely_Desktop.exe");
+                    var filePath = Path.Combine("Content", "Win-x86", "Remotely_Desktop.exe");
                     return await GetDesktopFile(filePath, organizationId);
                 }
             case "UbuntuDesktop":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "Linux-x64", "Remotely_Desktop");
+                    var filePath = Path.Combine("Content", "Linux-x64", "Remotely_Desktop");
                     return await GetDesktopFile(filePath, organizationId);
                 }
             case "MacOS-x64":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "MacOS-x64", "Remotely_Desktop");
+                    var filePath = Path.Combine("Content", "MacOS-x64", "Remotely_Desktop");
                     return await GetDesktopFile(filePath);
                 }
             case "MacOS-arm64":
                 {
-                    var filePath = Path.Combine(_hostEnv.WebRootPath, "Content", "MacOS-arm64", "Remotely_Desktop");
+                    var filePath = Path.Combine("Content", "MacOS-arm64", "Remotely_Desktop");
                     return await GetDesktopFile(filePath);
                 }
             default:
@@ -137,14 +137,9 @@ public class ClientDownloadsController : ControllerBase
         return File(fileBytes, "application/octet-stream", fileName);
     }
 
-    private async Task<IActionResult> GetDesktopFile(string filePath, string? organizationId = null)
+    private async Task<IActionResult> GetDesktopFile(string relativeFilePath, string? organizationId = null)
     {
-        var settings = await _dataService.GetSettings();
         await LogRequest(nameof(GetDesktopFile));
-
-        var effectiveScheme = settings.ForceClientHttps ? "https" : Request.Scheme;
-        var serverUrl = $"{effectiveScheme}://{Request.Host}";
-
         var defaultOrg = await _dataService.GetDefaultOrganization();
 
         // The default org will be used if unspecified, so might as well save the
@@ -154,10 +149,14 @@ public class ClientDownloadsController : ControllerBase
         {
             organizationId = null;
         }
+
+        var settings = await _dataService.GetSettings();
+        var effectiveScheme = settings.ForceClientHttps ? "https" : Request.Scheme;
+        var serverUrl = $"{effectiveScheme}://{Request.Host}";
+
         var embeddedData = new EmbeddedServerData(new Uri(serverUrl), organizationId);
-        var fileName = _embeddedDataSearcher.GetEncodedFileName(filePath, embeddedData);
-        var fileInfo = _hostEnv.WebRootFileProvider.GetFileInfo(filePath.Replace(_hostEnv.WebRootPath, string.Empty));
-        return File(fileInfo.CreateReadStream(), "application/octet-stream", fileName);
+        var fileName = _embeddedDataSearcher.GetEncodedFileName(relativeFilePath, embeddedData);
+        return File(relativeFilePath, "application/octet-stream", fileName);
     }
 
     private async Task<IActionResult> GetInstallFile(string organizationId, string platformID)

--- a/Server/API/CustomBinariesController.cs
+++ b/Server/API/CustomBinariesController.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Remotely.Server.Services;
+using Remotely.Shared.Models;
+using Remotely.Shared.Services;
+
+namespace Remotely.Server.API;
+
+[Route("api/custom-binaries")]
+[ApiController]
+public class CustomBinariesController(
+    IDataService _dataService,
+    IWebHostEnvironment _hostingEnvironment,
+    IEmbeddedServerDataProvider _embeddedData) : ControllerBase
+{
+    [HttpGet("win-x86/desktop/{organizationId}")]
+    public async Task<IActionResult> GetWinX86Desktop(string organizationId)
+    {
+        var embeddedData = await GetEmbeddedData(organizationId);
+        var filePath = Path.Combine(_hostingEnvironment.ContentRootPath, "AppData", "Win-x86", "Remotely_Desktop.exe");
+        var fileName = _embeddedData.GetEncodedFileName(filePath, embeddedData);
+        var rs = System.IO.File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return File(rs, "application/octet-stream", fileName);
+    }
+
+    [HttpGet("win-x64/desktop/{organizationId}")]
+    public async Task<IActionResult> GetWinX64Desktop(string organizationId)
+    {
+        var embeddedData = await GetEmbeddedData(organizationId);
+        var filePath = Path.Combine(_hostingEnvironment.ContentRootPath, "AppData", "Win-x64", "Remotely_Desktop.exe");
+        var fileName = _embeddedData.GetEncodedFileName(filePath, embeddedData);
+        var rs = System.IO.File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return File(rs, "application/octet-stream", fileName);
+    }
+
+    private async Task<EmbeddedServerData> GetEmbeddedData(string? organizationId)
+    {
+        var defaultOrg = await _dataService.GetDefaultOrganization();
+
+        // The default org will be used if unspecified, so might as well save the
+        // space in the file name.
+        if (defaultOrg.IsSuccess &&
+            defaultOrg.Value.ID.Equals(organizationId, StringComparison.OrdinalIgnoreCase))
+        {
+            organizationId = null;
+        }
+
+        var settings = await _dataService.GetSettings();
+        var effectiveScheme = settings.ForceClientHttps ? "https" : Request.Scheme;
+        var serverUrl = $"{effectiveScheme}://{Request.Host}";
+        return new EmbeddedServerData(new Uri(serverUrl), organizationId);
+    }
+}

--- a/Server/Components/AuthorizedIndex.razor
+++ b/Server/Components/AuthorizedIndex.razor
@@ -19,17 +19,6 @@
 @code {
     private SettingsModel? _settings;
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (User is not null &&
-            _settings?.Require2FA == true &&
-            !User.TwoFactorEnabled)
-        {
-            NavManager.NavigateTo("/TwoFactorRequired");
-        }
-        await base.OnAfterRenderAsync(firstRender);
-    }
-
     protected override async Task OnInitializedAsync()
     {
         _settings = await DataService.GetSettings();

--- a/Server/Components/Devices/DeviceCard.razor
+++ b/Server/Components/Devices/DeviceCard.razor
@@ -59,7 +59,9 @@
         {
             foreach (var kvp in _fileUploadProgressLookup)
             {
-                <AlertBanner Message="@GetProgressMessage(kvp.Key)" />
+                <div class="alert alert-info">
+                    @(GetProgressMessage(kvp.Key))
+                </div>
             }
         } 
         <div>

--- a/Server/Components/Layout/MainLayout.razor
+++ b/Server/Components/Layout/MainLayout.razor
@@ -1,6 +1,7 @@
 ﻿@using Remotely.Server.Components 
 @using Remotely.Server.Auth 
 @inherits LayoutComponentBase
+@inject NavigationManager NavMan
 
 <AuthorizeView Policy="@PolicyNames.TwoFactorRequired">
     <Authorized>
@@ -25,7 +26,7 @@
                 <div class="col-sm-12">
                     <p>Two-factor authentication is required.  Click the button below to set up your authenticator app.</p>
                     <p>
-                        <a href="Account/Manage/TwoFactorAuthentication" class="btn btn-primary">Enable 2FA</a>
+                        <button class="btn btn-primary" @onclick="NavigateToTwoFactor">Enable 2FA</button>
                     </p>
                 </div>
             </div>
@@ -43,3 +44,10 @@
 <ToastHarness />
 <LoaderHarness />
 <ModalHarness />
+
+@code {
+    private void NavigateToTwoFactor()
+    {
+        NavMan.NavigateTo("/Account/Manage/TwoFactorAuthentication", true);
+    }
+}

--- a/Server/Components/Layout/NavMenu.razor
+++ b/Server/Components/Layout/NavMenu.razor
@@ -32,6 +32,20 @@
             </NavLink>
         </li>
 
+
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="downloads">
+                <span class="oi oi-cloud-download" aria-hidden="true"></span> Downloads
+            </NavLink>
+        </li>
+
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="/RemoteControl/Viewer" target="_blank">
+                <span class="oi oi-monitor" aria-hidden="true"></span> Remote Control
+            </NavLink>
+
+        </li>
+
         <AuthorizeView>
             <Authorized>
                 <li class="nav-item px-3">
@@ -58,17 +72,6 @@
             </Authorized>
         </AuthorizeView>
 
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="/RemoteControl/Viewer" target="_blank">
-                <span class="oi oi-monitor" aria-hidden="true"></span> Remote Control
-            </NavLink>
-
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="downloads">
-                <span class="oi oi-cloud-download" aria-hidden="true"></span> Downloads
-            </NavLink>
-        </li>
 
         @if (_user?.IsAdministrator == true)
         {

--- a/Server/Components/Layout/NavMenu.razor
+++ b/Server/Components/Layout/NavMenu.razor
@@ -25,26 +25,20 @@
 
 <div class="@NavMenuCssClass" @onclick="ToggleNavMenu">
     <ul class="nav flex-column">
+
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
         </li>
 
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="/RemoteControl/Viewer" target="_blank">
-                <span class="oi oi-monitor" aria-hidden="true"></span> Remote Control
-            </NavLink>
-
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="downloads">
-                <span class="oi oi-cloud-download" aria-hidden="true"></span> Downloads
-            </NavLink>
-        </li>
-
         <AuthorizeView>
             <Authorized>
+                <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="deploy">
+                        <span class="oi oi-data-transfer-upload" aria-hidden="true"></span> Deploy
+                    </NavLink>
+                </li>
                 <li class="nav-item px-3">
                     <NavLink class="nav-link" href="scripts">
                         <span class="oi oi-script" aria-hidden="true"></span> Scripts
@@ -63,6 +57,18 @@
 
             </Authorized>
         </AuthorizeView>
+
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="/RemoteControl/Viewer" target="_blank">
+                <span class="oi oi-monitor" aria-hidden="true"></span> Remote Control
+            </NavLink>
+
+        </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="downloads">
+                <span class="oi oi-cloud-download" aria-hidden="true"></span> Downloads
+            </NavLink>
+        </li>
 
         @if (_user?.IsAdministrator == true)
         {

--- a/Server/Components/Pages/Deploy.razor
+++ b/Server/Components/Pages/Deploy.razor
@@ -68,8 +68,8 @@
     Attended Support
 </h4>
 <p class="text-info">
-    You can upload custom versions of the attended support client (i.e. "Remotely_Desktop.exe") 
-    and send the download link to end-users when they need support. For example, you could sign 
+    You can upload custom versions of the attended support client (i.e. "Remotely_Desktop.exe")
+    and send the download link to end-users when they need support. For example, you could sign
     the EXE with a commercial certificate so the end-user (hopefully) doesn't see a SmartScreen
     warning about the file.
 </p>
@@ -91,20 +91,28 @@
         }
         else if (_winX64File?.PhysicalPath is not null)
         {
-            <div class="text-primary mb-2">
+            <div class="text-info mb-2">
                 Created Date: @(_winX64CreatedDate) UTC
             </div>
         }
 
-        <div class="mb-2">
-            <FileInputButton ClassNames="btn btn-primary"
-                             OnChanged="HandleWin64FileChanged">
-                <ButtonContent>
-                    <i class="oi oi-data-transfer-upload" title="Upload File"></i>
-                    <span class="ms-2">Upload File</span>
-                </ButtonContent>
-            </FileInputButton>
-        </div>
+        @if (_isServerAdmin)
+        {
+            <div class="mb-2">
+                <FileInputButton ClassNames="btn btn-primary"
+                                 OnChanged="HandleWin64FileChanged">
+                    <ButtonContent>
+                        <i class="oi oi-data-transfer-upload" title="Upload File"></i>
+                        <span class="ms-2">Upload File</span>
+                    </ButtonContent>
+                </FileInputButton>
+                <div class="mt-1">
+                    <span class="text-primary">
+                        Note: Only server admins will have this button.
+                    </span>
+                </div>
+            </div>
+        }
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_winX64Uri" />
@@ -120,7 +128,7 @@
             <strong>Windows 10/11 (32-Bit)</strong>
         </div>
 
-        @if(_winX86File?.Exists != true)
+        @if (_winX86File?.Exists != true)
         {
             <div class="text-danger mb-2">
                 Note: A custom binary for this file hasn't been uploaded yet.
@@ -128,20 +136,28 @@
         }
         else if (_winX86File?.PhysicalPath is not null)
         {
-            <div class="text-primary mb-2">
+            <div class="text-info mb-2">
                 Created Date: @(_winX86CreatedDate) UTC
             </div>
         }
 
-        <div class="mb-2">
-            <FileInputButton ClassNames="btn btn-primary"
-                             OnChanged="HandleWin86FileChanged">
-                <ButtonContent>
-                    <i class="oi oi-data-transfer-upload" title="Upload File"></i>
-                    <span class="ms-2">Upload File</span>
-                </ButtonContent>
-            </FileInputButton>
-        </div>
+        @if (_isServerAdmin)
+        {
+            <div class="mb-2">
+                <FileInputButton ClassNames="btn btn-primary"
+                                 OnChanged="HandleWin86FileChanged">
+                    <ButtonContent>
+                        <i class="oi oi-data-transfer-upload" title="Upload File"></i>
+                        <span class="ms-2">Upload File</span>
+                    </ButtonContent>
+                </FileInputButton>
+                <div class="mt-1">
+                    <span class="text-primary">
+                        Note: Only server admins will have this button.
+                    </span>
+                </div>
+            </div>
+        }
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_winX86Uri" />
@@ -165,6 +181,7 @@
     private string _winX86Uri = string.Empty;
     private bool _isLoading = false;
     private string _loadingMessage = string.Empty;
+    private bool _isServerAdmin;
     private DateTime _winX64CreatedDate;
     private DateTime _winX86CreatedDate;
 
@@ -177,6 +194,7 @@
             return;
         }
 
+        _isServerAdmin = userResult.Value.IsServerAdmin;
         _organizationId = userResult.Value.OrganizationID;
         _appDataDir = Path.Combine(HostEnv.ContentRootPath, "AppData");
         _winX64Uri = $"{NavMan.BaseUri}api/custom-binaries/win-x64/desktop/{_organizationId}";
@@ -247,8 +265,8 @@
 
     private void SetScriptContent()
     {
-        _windowsScript = 
-            $"Invoke-WebRequest -Uri '{NavMan.BaseUri}api/ClientDownloads/WindowsInstaller/{_organizationId}' -OutFile \"${{env:TEMP}}\\Install-Remotely.ps1\" -UseBasicParsing;"+
+        _windowsScript =
+            $"Invoke-WebRequest -Uri '{NavMan.BaseUri}api/ClientDownloads/WindowsInstaller/{_organizationId}' -OutFile \"${{env:TEMP}}\\Install-Remotely.ps1\" -UseBasicParsing;" +
             "Start-Process -FilePath 'powershell.exe' -ArgumentList (\"-executionpolicy\", \"bypass\", \"-f\", \"${env:TEMP}\\Install-Remotely.ps1\") -Verb RunAs;";
 
         _ubuntuScript = GetLinuxScript("UbuntuInstaller-x64");
@@ -258,6 +276,14 @@
 
     private async Task TrySaveFile(IFileInfo? fileInfo, InputFileChangeEventArgs ev)
     {
+        // Since this is server-side Blazor, it would be impossible to
+        // get to this point without being a server admin.  But we'll add
+        // it here to prevent any issues caused by future changes.
+        if (!_isServerAdmin)
+        {
+            return;
+        }
+
         await _writeLock.WaitAsync();
         try
         {

--- a/Server/Components/Pages/Deploy.razor
+++ b/Server/Components/Pages/Deploy.razor
@@ -1,18 +1,29 @@
 ﻿@page "/deploy"
+@using Microsoft.Extensions.FileProviders
+@using System.Diagnostics
 @attribute [Authorize]
 @inject NavigationManager NavMan
 @inject IAuthService Auth
 @inject IDataService DataService
 @inject IJsInterop JsInterop
 @inject IToastService Toasts
+@inject IWebHostEnvironment HostEnv
 @inject ILogger<Deploy> Logger
 
-<h3>Deploy Scripts</h3>
-<p class="text-info col-sm-12 mb-4">
+@if (_isLoading)
+{
+    <LoadingSignal StatusMessage="@_loadingMessage" />
+}
+
+<h4 class="text-success mt-3">
+    Persistent Agents
+</h4>
+<p class="text-info mb-3">
     Copy and paste on a remote computer to install the agent.
 </p>
 
 <div class="row">
+
     <div class="col-sm-12 mb-3">
         <div class="mb-1">
             <strong>Windows 10/11 (32-Bit and 64-Bit)</strong>
@@ -53,33 +64,125 @@
     </div>
 </div>
 
+<h4 class="text-success mt-3">
+    Attended Support
+</h4>
+<p class="text-info">
+    You can upload custom versions of the attended support client (i.e. "Remotely_Desktop.exe") 
+    and send the download link to end-users when they need support. For example, you could sign 
+    the EXE with a commercial certificate so the end-user (hopefully) doesn't see a SmartScreen
+    warning about the file.
+</p>
+<p class="mb-3 text-warning">
+    NOTE: These binaries must be manually updated each time a new Docker image is pulled.
+</p>
+
+<div class="row">
+    <div class="col-sm-12 mb-4">
+        <div class="mb-1">
+            <strong>Windows 10/11 (64-Bit)</strong>
+        </div>
+
+        @if (_winX64File?.Exists != true)
+        {
+            <div class="text-danger mb-2">
+                Note: A custom binary for this file hasn't been uploaded yet.
+            </div>
+        }
+        else if (_winX64File?.PhysicalPath is not null)
+        {
+            <div class="text-primary mb-2">
+                Created Date: @(_winX64CreatedDate) UTC
+            </div>
+        }
+
+        <div class="mb-2">
+            <FileInputButton ClassNames="btn btn-primary"
+                             OnChanged="HandleWin64FileChanged">
+                <ButtonContent>
+                    <i class="oi oi-data-transfer-upload" title="Upload File"></i>
+                    <span class="ms-2">Upload File</span>
+                </ButtonContent>
+            </FileInputButton>
+        </div>
+
+        <div class="input-group">
+            <input type="text" class="form-control" readonly value="@_winX64Uri" />
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_winX64Uri)">
+                <i class="oi oi-clipboard"></i>
+            </button>
+        </div>
+
+    </div>
+
+    <div class="col-sm-12 mb-4">
+        <div class="mb-1">
+            <strong>Windows 10/11 (32-Bit)</strong>
+        </div>
+
+        @if(_winX86File?.Exists != true)
+        {
+            <div class="text-danger mb-2">
+                Note: A custom binary for this file hasn't been uploaded yet.
+            </div>
+        }
+        else if (_winX86File?.PhysicalPath is not null)
+        {
+            <div class="text-primary mb-2">
+                Created Date: @(_winX86CreatedDate) UTC
+            </div>
+        }
+
+        <div class="mb-2">
+            <FileInputButton ClassNames="btn btn-primary"
+                             OnChanged="HandleWin86FileChanged">
+                <ButtonContent>
+                    <i class="oi oi-data-transfer-upload" title="Upload File"></i>
+                    <span class="ms-2">Upload File</span>
+                </ButtonContent>
+            </FileInputButton>
+        </div>
+
+        <div class="input-group">
+            <input type="text" class="form-control" readonly value="@_winX86Uri" />
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_winX86Uri)">
+                <i class="oi oi-clipboard"></i>
+            </button>
+        </div>
+    </div>
+</div>
+
 @code {
-    private string? _organizationId;
-    private bool _isAuthenticated;
+    private static readonly SemaphoreSlim _writeLock = new(1, 1);
+    private string _organizationId = string.Empty;
     private string _windowsScript = string.Empty;
     private string _ubuntuScript = string.Empty;
     private string _manjaroScript = string.Empty;
+    private string _appDataDir = string.Empty;
+    private IFileInfo? _winX64File;
+    private IFileInfo? _winX86File;
+    private string _winX64Uri = string.Empty;
+    private string _winX86Uri = string.Empty;
+    private bool _isLoading = false;
+    private string _loadingMessage = string.Empty;
+    private DateTime _winX64CreatedDate;
+    private DateTime _winX86CreatedDate;
 
     protected override async Task OnInitializedAsync()
     {
-        _isAuthenticated = await Auth.IsAuthenticated();
+        var userResult = await Auth.GetUser();
+        if (!userResult.IsSuccess)
+        {
+            NavMan.NavigateTo("/", false);
+            return;
+        }
 
-        if (_isAuthenticated)
-        {
-            var userResult = await Auth.GetUser();
-            if (userResult.IsSuccess)
-            {
-                _organizationId = userResult.Value.OrganizationID;
-            }
-        }
-        else
-        {
-            var orgResult = await DataService.GetDefaultOrganization();
-            if (orgResult.IsSuccess)
-            {
-                _organizationId = orgResult.Value.ID;
-            }
-        }
+        _organizationId = userResult.Value.OrganizationID;
+        _appDataDir = Path.Combine(HostEnv.ContentRootPath, "AppData");
+        _winX64Uri = $"{NavMan.BaseUri}api/custom-binaries/win-x64/desktop/{_organizationId}";
+        _winX86Uri = $"{NavMan.BaseUri}api/custom-binaries/win-x86/desktop/{_organizationId}";
+
+        SetFileInfos();
 
         SetScriptContent();
 
@@ -104,6 +207,44 @@
         Toasts.ShowToast2("Failed to set clipboard content", ToastType.Error);
     }
 
+
+    private string GetLinuxScript(string platformId)
+    {
+        return
+            $"sudo rm -f /tmp/Install-Remotely.sh && " +
+            $"sudo wget -q -O /tmp/Install-Remotely.sh {NavMan.BaseUri}api/ClientDownloads/{platformId}/{_organizationId} && " +
+            $"sudo chmod +x /tmp/Install-Remotely.sh && " +
+            $"sudo /tmp/Install-Remotely.sh";
+    }
+
+
+    private async Task HandleWin64FileChanged(InputFileChangeEventArgs ev)
+    {
+        await TrySaveFile(_winX64File, ev);
+    }
+
+    private async Task HandleWin86FileChanged(InputFileChangeEventArgs ev)
+    {
+        await TrySaveFile(_winX86File, ev);
+    }
+
+    private void SetFileInfos()
+    {
+        _winX64File = HostEnv.ContentRootFileProvider.GetFileInfo("AppData/Win-x64/Remotely_Desktop.exe");
+        if (_winX64File?.Exists == true && _winX64File?.PhysicalPath is not null)
+        {
+            var fileInfo = new FileInfo(_winX64File.PhysicalPath);
+            _winX64CreatedDate = fileInfo.CreationTimeUtc;
+        }
+
+        _winX86File = HostEnv.ContentRootFileProvider.GetFileInfo("AppData/Win-x86/Remotely_Desktop.exe");
+        if (_winX86File?.Exists == true && _winX86File?.PhysicalPath is not null)
+        {
+            var fileInfo = new FileInfo(_winX86File.PhysicalPath);
+            _winX86CreatedDate = fileInfo.CreationTimeUtc;
+        }
+    }
+
     private void SetScriptContent()
     {
         _windowsScript = 
@@ -115,12 +256,39 @@
         _manjaroScript = GetLinuxScript("ManjaroInstaller-x64");
     }
 
-    private string GetLinuxScript(string platformId)
+    private async Task TrySaveFile(IFileInfo? fileInfo, InputFileChangeEventArgs ev)
     {
-        return 
-            $"sudo rm -f /tmp/Install-Remotely.sh && " +
-            $"sudo wget -q -O /tmp/Install-Remotely.sh {NavMan.BaseUri}api/ClientDownloads/{platformId}/{_organizationId} && " +
-            $"sudo chmod +x /tmp/Install-Remotely.sh && " +
-            $"sudo /tmp/Install-Remotely.sh";
+        await _writeLock.WaitAsync();
+        try
+        {
+            if (fileInfo?.PhysicalPath is null)
+            {
+                Toasts.ShowToast2("Unable to find save path", ToastType.Error);
+                return;
+            }
+
+            _loadingMessage = "Uploading file";
+            _isLoading = true;
+            await InvokeAsync(StateHasChanged);
+
+            _ = Directory.CreateDirectory(Path.GetDirectoryName(fileInfo.PhysicalPath)!);
+            await using var rs = ev.File.OpenReadStream(500_000_000);
+            await using var fs = File.Open(fileInfo.PhysicalPath, FileMode.Create);
+            await rs.CopyToAsync(fs);
+            Toasts.ShowToast2("Custom binary uploaded successfully", ToastType.Success);
+            SetFileInfos();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error while uploading custom binary.");
+            Toasts.ShowToast2("Failed to upload custom binary", ToastType.Error);
+        }
+        finally
+        {
+            _writeLock.Release();
+            _isLoading = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
+
 }

--- a/Server/Components/Pages/Deploy.razor
+++ b/Server/Components/Pages/Deploy.razor
@@ -1,0 +1,126 @@
+﻿@page "/deploy"
+@attribute [Authorize]
+@inject NavigationManager NavMan
+@inject IAuthService Auth
+@inject IDataService DataService
+@inject IJsInterop JsInterop
+@inject IToastService Toasts
+@inject ILogger<Deploy> Logger
+
+<h3>Deploy Scripts</h3>
+<p class="text-info col-sm-12 mb-4">
+    Copy and paste on a remote computer to install the agent.
+</p>
+
+<div class="row">
+    <div class="col-sm-12 mb-3">
+        <div class="mb-1">
+            <strong>Windows 10/11 (32-Bit and 64-Bit)</strong>
+        </div>
+
+        <div class="input-group">
+            <input type="text" class="form-control" readonly value="@_windowsScript" />
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_windowsScript)">
+                <i class="oi oi-clipboard"></i>
+            </button>
+        </div>
+    </div>
+
+    <div class="col-sm-12 mb-3">
+        <div class="mb-1">
+            <strong>Ubuntu (64-Bit)</strong>
+        </div>
+
+        <div class="input-group">
+            <input type="text" class="form-control" readonly value="@_ubuntuScript" />
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_ubuntuScript)">
+                <i class="oi oi-clipboard"></i>
+            </button>
+        </div>
+    </div>
+
+    <div class="col-sm-12 mb-3">
+        <div class="mb-1">
+            <strong>Manjaro (64-Bit)</strong>
+        </div>
+
+        <div class="input-group">
+            <input type="text" class="form-control" readonly value="@_manjaroScript" />
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_manjaroScript)">
+                <i class="oi oi-clipboard"></i>
+            </button>
+        </div>
+    </div>
+</div>
+
+@code {
+    private string? _organizationId;
+    private bool _isAuthenticated;
+    private string _windowsScript = string.Empty;
+    private string _ubuntuScript = string.Empty;
+    private string _manjaroScript = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _isAuthenticated = await Auth.IsAuthenticated();
+
+        if (_isAuthenticated)
+        {
+            var userResult = await Auth.GetUser();
+            if (userResult.IsSuccess)
+            {
+                _organizationId = userResult.Value.OrganizationID;
+            }
+        }
+        else
+        {
+            var orgResult = await DataService.GetDefaultOrganization();
+            if (orgResult.IsSuccess)
+            {
+                _organizationId = orgResult.Value.ID;
+            }
+        }
+
+        SetScriptContent();
+
+        await base.OnInitializedAsync();
+    }
+
+    private async Task CopyToClipboard(string text)
+    {
+        try
+        {
+            var result = await JsInterop.SetClipboardText(text);
+            if (result)
+            {
+                Toasts.ShowToast2("Script copied to clipboard", ToastType.Success);
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error while copying script to clipboard.");
+        }
+        Toasts.ShowToast2("Failed to set clipboard content", ToastType.Error);
+    }
+
+    private void SetScriptContent()
+    {
+        _windowsScript = 
+            $"Invoke-WebRequest -Uri '{NavMan.BaseUri}api/ClientDownloads/WindowsInstaller/{_organizationId}' -OutFile \"${{env:TEMP}}\\Install-Remotely.ps1\" -UseBasicParsing;"+
+            "Start-Process -FilePath 'powershell.exe' -ArgumentList (\"-executionpolicy\", \"bypass\", \"-f\", \"${env:TEMP}\\Install-Remotely.ps1\") -Verb RunAs;";
+
+        _ubuntuScript = GetLinuxScript("UbuntuInstaller-x64");
+
+        _manjaroScript = GetLinuxScript("ManjaroInstaller-x64");
+    }
+
+    private string GetLinuxScript(string platformId)
+    {
+        return 
+            $"sudo rm -f /tmp/Install-Remotely.sh && " +
+            $"sudo wget -q -O /tmp/Install-Remotely.sh {NavMan.BaseUri}api/ClientDownloads/{platformId}/{_organizationId} && " +
+            $"sudo chmod +x /tmp/Install-Remotely.sh && " +
+            $"sudo /tmp/Install-Remotely.sh";
+    }
+}

--- a/Server/Components/Pages/Deploy.razor
+++ b/Server/Components/Pages/Deploy.razor
@@ -31,7 +31,7 @@
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_windowsScript" />
-            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_windowsScript)">
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyScriptToClipboard(_windowsScript)">
                 <i class="oi oi-clipboard"></i>
             </button>
         </div>
@@ -44,7 +44,7 @@
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_ubuntuScript" />
-            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_ubuntuScript)">
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyScriptToClipboard(_ubuntuScript)">
                 <i class="oi oi-clipboard"></i>
             </button>
         </div>
@@ -57,7 +57,7 @@
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_manjaroScript" />
-            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_manjaroScript)">
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyScriptToClipboard(_manjaroScript)">
                 <i class="oi oi-clipboard"></i>
             </button>
         </div>
@@ -116,7 +116,7 @@
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_winX64Uri" />
-            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_winX64Uri)">
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyUriToClipboard(_winX64Uri)">
                 <i class="oi oi-clipboard"></i>
             </button>
         </div>
@@ -161,7 +161,7 @@
 
         <div class="input-group">
             <input type="text" class="form-control" readonly value="@_winX86Uri" />
-            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyToClipboard(_winX86Uri)">
+            <button class="btn btn-primary" type="button" id="button-addon2" @onclick="() => CopyUriToClipboard(_winX86Uri)">
                 <i class="oi oi-clipboard"></i>
             </button>
         </div>
@@ -207,11 +207,11 @@
         await base.OnInitializedAsync();
     }
 
-    private async Task CopyToClipboard(string text)
+    private async Task CopyScriptToClipboard(string script)
     {
         try
         {
-            var result = await JsInterop.SetClipboardText(text);
+            var result = await JsInterop.SetClipboardText(script);
             if (result)
             {
                 Toasts.ShowToast2("Script copied to clipboard", ToastType.Success);
@@ -225,6 +225,23 @@
         Toasts.ShowToast2("Failed to set clipboard content", ToastType.Error);
     }
 
+    private async Task CopyUriToClipboard(string uri)
+    {
+        try
+        {
+            var result = await JsInterop.SetClipboardText(uri);
+            if (result)
+            {
+                Toasts.ShowToast2("URI copied to clipboard", ToastType.Success);
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error while copying URI to clipboard.");
+        }
+        Toasts.ShowToast2("Failed to set clipboard content", ToastType.Error);
+    }
 
     private string GetLinuxScript(string platformId)
     {

--- a/Server/Components/Pages/Downloads.razor
+++ b/Server/Components/Pages/Downloads.razor
@@ -9,9 +9,13 @@
 @inject NavigationManager NavManager
 @inject ILogger<Downloads> Logger 
 
-<div class="alert alert-info">
-    Looking for background agents?  Head to the <a href="/deploy">Deploy</a> page!
-</div>
+@if (_isAuthenticated)
+{
+    <div class="alert alert-info">
+        Check out the <a href="/deploy">Deploy</a> page for a copy-and-paste deploy script!
+    </div>
+}
+
 
 <div class="row mb-3">
     <h4>Portable Instant Support Clients</h4>
@@ -37,57 +41,163 @@
         </p>
     </div>
     @*<div class="col-sm-6 mb-3">
-        <strong>macOS x64 (10.12 - 10.15)</strong>
-        <p>
-            <a target="_blank" href="/api/ClientDownloads/Desktop/MacOS-x64/@_organizationId">macOS x64 Executable</a>
-        </p>
-        <strong>macOS arm64 (11.01)</strong>
-        <p>
-            <a target="_blank" href="/api/ClientDownloads/Desktop/MacOS-arm64/@_organizationId">macOS arm64 Executable</a>
-        </p>
+    <strong>macOS x64 (10.12 - 10.15)</strong>
+    <p>
+    <a target="_blank" href="/api/ClientDownloads/Desktop/MacOS-x64/@_organizationId">macOS x64 Executable</a>
+    </p>
+    <strong>macOS arm64 (11.01)</strong>
+    <p>
+    <a target="_blank" href="/api/ClientDownloads/Desktop/MacOS-arm64/@_organizationId">macOS arm64 Executable</a>
+    </p>
     </div>*@
 </div>
 
 
-
 <div class="row">
-    <h4>Binaries Only</h4>
+    <h4>Resident Agents</h4>
+
     <p class="text-info col-sm-12 mb-2">
-        Archives containing the agent binaries only.
+        Installable background agents that provide unattended access and remote scripting.
     </p>
-    <div class="col-sm-6 mb-3">
-        <strong>Windows 10 / 11 (64-Bit and 32-Bit)</strong>
-        <p>
-            <a target="_blank" href="/Content/Remotely-Win-x64.zip">Windows x64 Files Only</a>
-            <br />
-            <a target="_blank" href="/Content/Remotely-Win-x86.zip">Windows x86 Files Only</a>
-        </p>
 
-    </div>
+    @if (!_isAuthenticated)
+    {
+        <div class="col-sm-6 mb-3">
+            <h6>Must be logged in to download.</h6>
+        </div>
 
-    <div class="col-sm-6 mb-3">
-        <strong>Linux 64-Bit</strong>
-        <p>
-            <a target="_blank" href="/API/ClientDownloads/ManjaroInstaller-x64/@_organizationId">Manjaro x64 Bash Installer</a>
-            <br />
-            <a target="_blank" href="/Content/Remotely-Linux.zip">Linux x64 Files Only</a>
-        </p>
-    </div>
+    }
+    else
+    {
+        <div class="col-sm-6 mb-3">
+            <strong>Windows 10 / 11 (64-Bit and 32-Bit)</strong>
+            <p>
+                <a target="_blank" href="/API/ClientDownloads/WindowsInstaller/@_organizationId">Windows PowerShell Installer</a>
+                <br />
+                <a target="_blank" href="/Content/Remotely-Win-x64.zip">Windows x64 Files Only</a>
+                <br />
+                <a target="_blank" href="/Content/Remotely-Win-x86.zip">Windows x86 Files Only</a>
+            </p>
 
-    @* There is currently no bandwidth for Mac development.  The community will need to pick it up. *@
-    @*<div class="col-sm-6 mb-3">
-        <strong>macOS x64 (10.12 - 10.15)</strong>
-        <p>
-            <a target="_blank" href="/Content/Remotely-MacOS-x64.zip">macOS x64 Files Only</a>
-        </p>
-    </div>
+            <p>
+                <div class="small">Example Quiet Install:</div>
 
-     <div class="col-sm-6 mb-3">
-        <strong>macOS arm64</strong>
-        <p>
-            <a target="_blank" href="/Content/Remotely-MacOS-arm64.zip">macOS arm64 Files Only</a>
-        </p>
-    </div> *@
+                <code class="label label-default small">
+                    powershell.exe -ExecutionPolicy Bypass -F {path}\Install-Remotely.ps1
+                    -install
+                    -quiet
+                    -organizationid "0b3d706b-9c5d-41e6-8ae9-5720d16324e6"
+                    -serverurl "https://remotely.mytechshop.com"
+                </code>
+            </p>
+            <p>
+                <div class="small">Example Quiet Uninstall:</div>
+
+                <code class="label label-default small">powershell.exe -ExecutionPolicy Bypass -F Install-Remotely.ps1 -uninstall -quiet</code>
+            </p>
+            <p>
+                <div class="small">Example Local Install:</div>
+
+                <code class="label label-default small">
+                    powershell.exe -ExecutionPolicy Bypass -F {path}\Install-Remotely.ps1
+                    -install
+                    -quiet
+                    -organizationid "0b3d706b-9c5d-41e6-8ae9-5720d16324e6"
+                    -serverurl "https://remotely.mytechshop.com"
+                    -path "[path]\Remotely-Win-x64.zip"
+                </code>
+            </p>
+            <p>
+                <div class="small">All Override Options:</div>
+
+                <code class="label label-default small">
+                    powershell.exe -ExecutionPolicy Bypass -F {path}\Install-Remotely.ps1
+                    -install -quiet -supportshortcut
+                    -organizationid "0b3d706b-9c5d-41e6-8ae9-5720d16324e6"
+                    -serverurl "https://remotely.mytechshop.com"
+                    -devicegroup "Customer Group 1"
+                    -devicealias "Front Desk"
+                    -deviceuuid "eebb4d87-5459-4976-989e-a7876dffc69c"
+                </code>
+            </p>
+        </div>
+
+        <div class="col-sm-6 mb-3">
+            <strong>Linux 64-Bit</strong>
+            <p>
+                <a target="_blank" href="/API/ClientDownloads/UbuntuInstaller-x64/@_organizationId">Ubuntu x64 Bash Installer</a>
+                <br />
+                <a target="_blank" href="/API/ClientDownloads/ManjaroInstaller-x64/@_organizationId">Manjaro x64 Bash Installer</a>
+                <br />
+                <a target="_blank" href="/Content/Remotely-Linux.zip">Linux x64 Files Only</a>
+            </p>
+            <p>
+                <div class="small">Example Install:</div>
+
+                <code class="label label-default small">sudo [path]/Install-Ubuntu-x64.sh</code>
+            </p>
+            <p>
+                <div class="small">Example Local Install:</div>
+
+                <code class="label label-default small">sudo [path]/Install-Ubuntu-x64.sh --path [path]/Remotely-Linux.zip</code>
+            </p>
+            <p>
+                <div class="small">Uninstall:</div>
+
+                <code class="label label-default small">sudo [path]/Install-Ubuntu-x64.sh --uninstall</code>
+            </p>
+        </div>
+
+        <div class="col-sm-6 mb-3">
+            <strong>macOS x64 (10.12 - 10.15)</strong>
+            <p>
+                <a target="_blank" href="/API/ClientDownloads/MacOSInstaller-x64/@_organizationId">macOS x64 Bash Installer</a>
+                <br />
+                <a target="_blank" href="/Content/Remotely-MacOS-x64.zip">macOS x64 Files Only</a>
+            </p>
+
+            <p>
+                <div class="small">Example Install:</div>
+
+                <code class="label label-default small">sudo [path]/Install-MacOS-x64.sh</code>
+            </p>
+            <p>
+                <div class="small">Example Local Install:</div>
+
+                <code class="label label-default small">sudo [path]/Install-MacOS-x64.sh --path [path]/Remotely-MacOS-x64.zip</code>
+            </p>
+            <p>
+                <div class="small">Example Uninstall:</div>
+
+                <code class="label label-default small">sudo [path]/Install-MacOS-x64.sh --uninstall</code>
+            </p>
+        </div>
+
+        <div class="col-sm-6 mb-3">
+            <strong>macOS arm64</strong>
+            <p>
+                <a target="_blank" href="/API/ClientDownloads/MacOSInstaller-arm64/@_organizationId">macOS arm64 Bash Installer</a>
+                <br />
+                <a target="_blank" href="/Content/Remotely-MacOS-arm64.zip">macOS arm64 Files Only</a>
+            </p>
+
+            <p>
+                <div class="small">Example Install:</div>
+
+                <code class="label label-default small">sudo [path]/Install-MacOS-arm64.sh</code>
+            </p>
+            <p>
+                <div class="small">Example Local Install:</div>
+
+                <code class="label label-default small">sudo [path]/Install-MacOS-arm64.sh --path [path]/Remotely-MacOS-arm64.zip</code>
+            </p>
+            <p>
+                <div class="small">Example Uninstall:</div>
+
+                <code class="label label-default small">sudo [path]/Install-MacOS-arm64.sh --uninstall</code>
+            </p>
+        </div>
+    }
 
 </div>
 

--- a/Server/Components/Pages/Downloads.razor
+++ b/Server/Components/Pages/Downloads.razor
@@ -9,6 +9,10 @@
 @inject NavigationManager NavManager
 @inject ILogger<Downloads> Logger 
 
+<div class="alert alert-info">
+    Looking for background agents?  Head to the <a href="/deploy">Deploy</a> page!
+</div>
+
 <div class="row mb-3">
     <h4>Portable Instant Support Clients</h4>
     <p class="text-info col-sm-12 mb-2">
@@ -45,150 +49,45 @@
 </div>
 
 
+
 <div class="row">
-    <h4>Resident Agents</h4>
+    <h4>Binaries Only</h4>
     <p class="text-info col-sm-12 mb-2">
-        Installable background agents that provide unattended access and remote scripting.
+        Archives containing the agent binaries only.
     </p>
+    <div class="col-sm-6 mb-3">
+        <strong>Windows 10 / 11 (64-Bit and 32-Bit)</strong>
+        <p>
+            <a target="_blank" href="/Content/Remotely-Win-x64.zip">Windows x64 Files Only</a>
+            <br />
+            <a target="_blank" href="/Content/Remotely-Win-x86.zip">Windows x86 Files Only</a>
+        </p>
 
-    @if (!_isAuthenticated)
-    {
-        <div class="col-sm-6 mb-3">
-            <h6>Must be logged in to download.</h6>
-        </div>
+    </div>
 
-    }
-    else
-    {
-        <div class="col-sm-6 mb-3">
-            <strong>Windows 10 / 11 (64-Bit and 32-Bit)</strong>
-            <p>
-                <a target="_blank" href="/API/ClientDownloads/WindowsInstaller/@_organizationId">Windows PowerShell Installer</a>
-                <br />
-                <a target="_blank" href="/Content/Remotely-Win-x64.zip">Windows x64 Files Only</a>
-                <br />
-                <a target="_blank" href="/Content/Remotely-Win-x86.zip">Windows x86 Files Only</a>
-            </p>
+    <div class="col-sm-6 mb-3">
+        <strong>Linux 64-Bit</strong>
+        <p>
+            <a target="_blank" href="/API/ClientDownloads/ManjaroInstaller-x64/@_organizationId">Manjaro x64 Bash Installer</a>
+            <br />
+            <a target="_blank" href="/Content/Remotely-Linux.zip">Linux x64 Files Only</a>
+        </p>
+    </div>
 
-            <p>
-                <div class="small">Example Quiet Install:</div>
-                
-                <code class="label label-default small">
-                    powershell.exe -ExecutionPolicy Bypass -F {path}\Install-Remotely.ps1
-                    -install
-                    -quiet
-                    -organizationid "0b3d706b-9c5d-41e6-8ae9-5720d16324e6"
-                    -serverurl "https://remotely.mytechshop.com"
-                </code>
-            </p>
-            <p>
-                <div class="small">Example Quiet Uninstall:</div>
+    @* There is currently no bandwidth for Mac development.  The community will need to pick it up. *@
+    @*<div class="col-sm-6 mb-3">
+        <strong>macOS x64 (10.12 - 10.15)</strong>
+        <p>
+            <a target="_blank" href="/Content/Remotely-MacOS-x64.zip">macOS x64 Files Only</a>
+        </p>
+    </div>
 
-                <code class="label label-default small">powershell.exe -ExecutionPolicy Bypass -F Install-Remotely.ps1 -uninstall -quiet</code>
-            </p>
-            <p>
-                <div class="small">Example Local Install:</div>
-               
-                <code class="label label-default small">
-                    powershell.exe -ExecutionPolicy Bypass -F {path}\Install-Remotely.ps1
-                    -install
-                    -quiet
-                    -organizationid "0b3d706b-9c5d-41e6-8ae9-5720d16324e6"
-                    -serverurl "https://remotely.mytechshop.com"
-                    -path "[path]\Remotely-Win-x64.zip"
-                </code>
-            </p>
-            <p>
-                <div class="small">All Override Options:</div>
-                
-                <code class="label label-default small">
-                    powershell.exe -ExecutionPolicy Bypass -F {path}\Install-Remotely.ps1
-                    -install -quiet -supportshortcut
-                    -organizationid "0b3d706b-9c5d-41e6-8ae9-5720d16324e6"
-                    -serverurl "https://remotely.mytechshop.com"
-                    -devicegroup "Customer Group 1"
-                    -devicealias "Front Desk"
-                    -deviceuuid "eebb4d87-5459-4976-989e-a7876dffc69c"
-                </code>
-            </p>
-        </div>
-
-        <div class="col-sm-6 mb-3">
-            <strong>Linux 64-Bit</strong>
-            <p>
-                <a target="_blank" href="/API/ClientDownloads/UbuntuInstaller-x64/@_organizationId">Ubuntu x64 Bash Installer</a>
-                <br />
-                <a target="_blank" href="/API/ClientDownloads/ManjaroInstaller-x64/@_organizationId">Manjaro x64 Bash Installer</a>
-                <br />
-                <a target="_blank" href="/Content/Remotely-Linux.zip">Linux x64 Files Only</a>
-            </p>
-            <p>
-                <div class="small">Example Install:</div>
-                
-                <code class="label label-default small">sudo [path]/Install-Ubuntu-x64.sh</code>
-            </p>
-            <p>
-                <div class="small">Example Local Install:</div>
-              
-                <code class="label label-default small">sudo [path]/Install-Ubuntu-x64.sh --path [path]/Remotely-Linux.zip</code>
-            </p>
-            <p>
-                <div class="small">Uninstall:</div>
-
-                <code class="label label-default small">sudo [path]/Install-Ubuntu-x64.sh --uninstall</code>
-            </p>
-        </div>
-
-        <div class="col-sm-6 mb-3">
-            <strong>macOS x64 (10.12 - 10.15)</strong>
-            <p>
-                <a target="_blank" href="/API/ClientDownloads/MacOSInstaller-x64/@_organizationId">macOS x64 Bash Installer</a>
-                <br />
-                <a target="_blank" href="/Content/Remotely-MacOS-x64.zip">macOS x64 Files Only</a>
-            </p>
-
-            <p>
-                <div class="small">Example Install:</div>
-                
-                <code class="label label-default small">sudo [path]/Install-MacOS-x64.sh</code>
-            </p>
-            <p>
-                <div class="small">Example Local Install:</div>
-               
-                <code class="label label-default small">sudo [path]/Install-MacOS-x64.sh --path [path]/Remotely-MacOS-x64.zip</code>
-            </p>
-            <p>
-                <div class="small">Example Uninstall:</div>
-                
-                <code class="label label-default small">sudo [path]/Install-MacOS-x64.sh --uninstall</code>
-            </p>
-        </div>
-
-        <div class="col-sm-6 mb-3">
-            <strong>macOS arm64</strong>
-            <p>
-                <a target="_blank" href="/API/ClientDownloads/MacOSInstaller-arm64/@_organizationId">macOS arm64 Bash Installer</a>
-                <br />
-                <a target="_blank" href="/Content/Remotely-MacOS-arm64.zip">macOS arm64 Files Only</a>
-            </p>
-
-            <p>
-                <div class="small">Example Install:</div>
-
-                <code class="label label-default small">sudo [path]/Install-MacOS-arm64.sh</code>
-            </p>
-            <p>
-                <div class="small">Example Local Install:</div>
-
-                <code class="label label-default small">sudo [path]/Install-MacOS-arm64.sh --path [path]/Remotely-MacOS-arm64.zip</code>
-            </p>
-            <p>
-                <div class="small">Example Uninstall:</div>
-
-                <code class="label label-default small">sudo [path]/Install-MacOS-arm64.sh --uninstall</code>
-            </p>
-        </div>
-    }
+     <div class="col-sm-6 mb-3">
+        <strong>macOS arm64</strong>
+        <p>
+            <a target="_blank" href="/Content/Remotely-MacOS-arm64.zip">macOS arm64 Files Only</a>
+        </p>
+    </div> *@
 
 </div>
 

--- a/Server/Components/Pages/ServerConfig.razor
+++ b/Server/Components/Pages/ServerConfig.razor
@@ -345,9 +345,7 @@
                 <ValidationMessage For="() => Input.UseHttpLogging" />
             </div>
 
-            <div class="form-group mt-3">
-                <button type="button" class="btn btn-primary" @onclick="Save">Save</button>
-            </div>
+            <button id="saveButton" type="button" class="btn btn-lg btn-primary" @onclick="Save">Save</button>
         </EditForm>
     </div>
 </div>

--- a/Server/Components/Pages/ServerConfig.razor.css
+++ b/Server/Components/Pages/ServerConfig.razor.css
@@ -7,3 +7,9 @@
     white-space: nowrap;
     border-radius: 5px;
 }
+
+#saveButton {
+    position: fixed;
+    right: 40px;
+    bottom: 20px;
+}

--- a/Server/Components/Scripts/SavedScripts.razor
+++ b/Server/Components/Scripts/SavedScripts.razor
@@ -122,7 +122,7 @@
                             </div>
                             <div class="mt-2 col-md-6">
                                 <div>Server URL</div>
-                                <div class="small text-muted mt-1">The URL of the server that the device connects to (e.g. https://app.remotely.one).</div>
+                                <div class="small text-muted mt-1">The URL of the server that the device connects to (e.g. https://app.example.com).</div>
                                 <input type="text" readonly class="form-control" value="ServerUrl" />
                             </div>
                         </div>

--- a/Server/Components/_Imports.razor
+++ b/Server/Components/_Imports.razor
@@ -26,3 +26,4 @@
 @using Remotely.Server.Auth
 @using Remotely.Shared.Entities
 @using Remotely.Server.Models
+@using Remotely.Shared.Services;

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -9,5 +9,5 @@ WORKDIR /app
 
 ENTRYPOINT ["dotnet", "Remotely_Server.dll"]
 
-HEALTHCHECK --interval=5m --timeout=3s \
+HEALTHCHECK \
   CMD curl -f http://localhost:${ASPNETCORE_HTTP_PORTS}/api/healthcheck || exit 1

--- a/Server/Dockerfile.pipelines
+++ b/Server/Dockerfile.pipelines
@@ -9,5 +9,5 @@ WORKDIR /app
 
 ENTRYPOINT ["dotnet", "Remotely_Server.dll"]
 
-HEALTHCHECK --interval=5m --timeout=3s \
+HEALTHCHECK \
   CMD curl -f http://localhost:${ASPNETCORE_HTTP_PORTS}/api/healthcheck || exit 1

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -193,7 +193,6 @@ services.Configure<ForwardedHeadersOptions>(options =>
 services.AddSignalR(options =>
 {
     options.EnableDetailedErrors = builder.Environment.IsDevelopment();
-    options.MaximumParallelInvocationsPerClient = 5;
     options.MaximumReceiveMessageSize = 100_000;
 })
     .AddJsonProtocol(options =>
@@ -246,7 +245,7 @@ services.AddScoped<ISelectedCardsStore, SelectedCardsStore>();
 services.AddScoped<IExpiringTokenService, ExpiringTokenService>();
 services.AddScoped<IScriptScheduleDispatcher, ScriptScheduleDispatcher>();
 services.AddSingleton<IOtpProvider, OtpProvider>();
-services.AddSingleton<IEmbeddedServerDataSearcher, EmbeddedServerDataSearcher>();
+services.AddSingleton<IEmbeddedServerDataProvider, EmbeddedServerDataProvider>();
 services.AddSingleton<ILogsManager, LogsManager>();
 services.AddScoped<IThemeProvider, ThemeProvider>();
 services.AddScoped<IChatSessionStore, ChatSessionStore>();

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -14,25 +14,25 @@
 
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2">
+    <PackageReference Include="MailKit" Version="4.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
-    <PackageReference Include="QRCoder" Version="1.4.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageReference Include="QRCoder" Version="1.5.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Server/Services/JsInterop.cs
+++ b/Server/Services/JsInterop.cs
@@ -6,6 +6,8 @@ namespace Remotely.Server.Services;
 
 public interface IJsInterop
 {
+    void AddBeforeUnloadHandler();
+
     void AddClassName(ElementReference element, string className);
     ValueTask Alert(string message);
 
@@ -13,20 +15,25 @@ public interface IJsInterop
 
     ValueTask<bool> Confirm(string message);
 
+    ValueTask<int> GetCursorIndex(ElementReference terminalInput);
+
     void InvokeClick(string elementId);
 
+    void OpenWindow(string url, string target);
+
+    void PreventTabOut(ElementReference terminalInput);
+
     ValueTask<string> Prompt(string message);
-    void SetStyleProperty(ElementReference element, string propertyName, string value);
-    void StartDraggingY(ElementReference element, double clientY);
+    void ScrollToElement(ElementReference element);
 
     void ScrollToEnd(ElementReference element);
 
-    void AddBeforeUnloadHandler();
-    void OpenWindow(string url, string target);
-    void ScrollToElement(ElementReference element);
-    ValueTask<int> GetCursorIndex(ElementReference terminalInput);
-    void PreventTabOut(ElementReference terminalInput);
+    ValueTask<bool> SetClipboardText(string text);
+
+    void SetStyleProperty(ElementReference element, string propertyName, string value);
+    void StartDraggingY(ElementReference element, double clientY);
 }
+
 public class JsInterop : IJsInterop
 {
     private readonly IJSRuntime _jsRuntime;
@@ -95,6 +102,12 @@ public class JsInterop : IJsInterop
     {
         _jsRuntime.InvokeVoidAsync("scrollToEnd", element);
     }
+
+    public async ValueTask<bool> SetClipboardText(string text)
+    {
+        return await _jsRuntime.InvokeAsync<bool>("setClipboardText", text);
+    }
+
     public void SetStyleProperty(ElementReference element, string propertyName, string value)
     {
         _jsRuntime.InvokeVoidAsync("setStyleProperty", element, propertyName, value);

--- a/Server/wwwroot/interop.js
+++ b/Server/wwwroot/interop.js
@@ -42,6 +42,22 @@ window.scrollToElement = (element) => {
     }, 200);
 
 }
+
+/**
+ * @param {string} text
+ * @returns {Promise<boolean>}
+ */
+window.setClipboardText = async (text) => {
+    try {
+        await navigator.clipboard.writeText(text);
+        return true;
+    }
+    catch (ex) {
+        console.error(ex);
+        return false;
+    }
+}
+
 window.setStyleProperty = (element, propertyName, value) => {
     element.style[propertyName] = value;
 }

--- a/Shared/Services/EmbeddedServerDataProvider.cs
+++ b/Shared/Services/EmbeddedServerDataProvider.cs
@@ -2,30 +2,21 @@
 
 using Immense.RemoteControl.Shared;
 using MessagePack;
-using Microsoft.Extensions.Logging;
-using Remotely.Shared.Entities;
 using Remotely.Shared.Models;
-using Remotely.Shared.Utilities;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace Remotely.Shared.Services;
 
-public interface IEmbeddedServerDataSearcher
+public interface IEmbeddedServerDataProvider
 {
     string GetEncodedFileName(string filePath, EmbeddedServerData serverData);
     Result<EmbeddedServerData> TryGetEmbeddedData(string filePath);
 }
 
-public class EmbeddedServerDataSearcher() : IEmbeddedServerDataSearcher
+public class EmbeddedServerDataProvider : IEmbeddedServerDataProvider
 {
-    public static EmbeddedServerDataSearcher Instance { get; } = new();
+    public static EmbeddedServerDataProvider Instance { get; } = new();
 
     public string GetEncodedFileName(string filePath, EmbeddedServerData serverData)
     {

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.6" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/LoadTester/LoadTester.csproj
+++ b/Tests/LoadTester/LoadTester.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="Moq" Version="[4.18.4]" />
   </ItemGroup>
 

--- a/Tests/Server.Tests/Server.Tests.csproj
+++ b/Tests/Server.Tests/Server.Tests.csproj
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="[4.18.4]" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Shared.Tests/Shared.Tests.csproj
+++ b/Tests/Shared.Tests/Shared.Tests.csproj
@@ -13,10 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Utilities/Example_Nginx_Config.txt
+++ b/Utilities/Example_Nginx_Config.txt
@@ -1,6 +1,6 @@
 server {
     listen        80;
-    server_name   app.remotely.one *.app.remotely.one;
+    server_name   app.example.com *.app.example.com;
     location / {
         proxy_pass         http://localhost:5000;
         proxy_http_version 1.1;

--- a/Utilities/Publish.ps1
+++ b/Utilities/Publish.ps1
@@ -102,8 +102,8 @@ if ((Test-Path -Path "$Root\Agent\bin\publish\linux-x64") -eq $true) {
 dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime win-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\win-x64" "$Root\Agent"
 dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime linux-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\linux-x64" "$Root\Agent"
 dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime win-x86 --self-contained --configuration Release --output "$Root\Agent\bin\publish\win-x86" "$Root\Agent"
-#dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-x64" "$Root\Agent"
-#dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-arm64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-arm64" "$Root\Agent"
+dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-x64" "$Root\Agent"
+dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-arm64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-arm64" "$Root\Agent"
 
 New-Item -Path "$Root\Agent\bin\publish\win-x64\Desktop\" -ItemType Directory -Force
 New-Item -Path "$Root\Agent\bin\publish\win-x86\Desktop\" -ItemType Directory -Force

--- a/Utilities/Publish.ps1
+++ b/Utilities/Publish.ps1
@@ -102,8 +102,8 @@ if ((Test-Path -Path "$Root\Agent\bin\publish\linux-x64") -eq $true) {
 dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime win-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\win-x64" "$Root\Agent"
 dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime linux-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\linux-x64" "$Root\Agent"
 dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime win-x86 --self-contained --configuration Release --output "$Root\Agent\bin\publish\win-x86" "$Root\Agent"
-dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-x64" "$Root\Agent"
-dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-arm64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-arm64" "$Root\Agent"
+#dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-x64" "$Root\Agent"
+#dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-arm64 --self-contained --configuration Release --output "$Root\Agent\bin\publish\osx-arm64" "$Root\Agent"
 
 New-Item -Path "$Root\Agent\bin\publish\win-x64\Desktop\" -ItemType Directory -Force
 New-Item -Path "$Root\Agent\bin\publish\win-x86\Desktop\" -ItemType Directory -Force


### PR DESCRIPTION
I know it's bad practice to have multiple unrelated changes in a PR, but time is short.

Changes:
  - Removed occurrences of "remotely.one".
    -   The domain isn't being used anymore.
  - Use default Docker healthcheck times.
  - Fixed users being stuck when two-factor authentication enforcement is turned on.
  - Made the Save button fixed on the Server Config page.
  - The server URL (and optionally org ID) is now encoded in the attended support client's file name when downloaded.
  - Added a Deploy page.
    - You can now copy and paste an install script directly into the terminal to install the persistent agent.
    - Server admins can upload a custom version of the attended support client for distribution (e.g. commercially-signed).