### PR TITLE
Allow remote control consent and chat on Windows Login screen.

### DIFF
--- a/Agent/Services/Windows/AppLauncherWin.cs
+++ b/Agent/Services/Windows/AppLauncherWin.cs
@@ -49,8 +49,6 @@ public class AppLauncherWin : IAppLauncher
                         $" --org-name \"{orgName}\"" +
                         $" --org-id \"{orgId}\"",
                     targetSessionId: -1,
-                    forceConsoleSession: false,
-                    desktopName: "default",
                     hiddenWindow: false,
                     out var procInfo);
                 if (!result)
@@ -122,8 +120,6 @@ public class AppLauncherWin : IAppLauncher
                         $" --session-id \"{sessionId}\"" +
                         $" --access-key \"{accessKey}\"",
                     targetSessionId: targetSessionId,
-                    forceConsoleSession: Shlwapi.IsOS(OsType.OS_ANYSERVER) && targetSessionId == -1,
-                    desktopName: "default",
                     hiddenWindow: false,
                     out _);
                 if (!result)
@@ -180,8 +176,6 @@ public class AppLauncherWin : IAppLauncher
                         $" --viewers {string.Join(",", viewerIds)}",
 
                     targetSessionId: targetSessionID,
-                    forceConsoleSession: Shlwapi.IsOS(OsType.OS_ANYSERVER) && targetSessionID == -1,
-                    desktopName: "default",
                     hiddenWindow: false,
                     out _);
 

--- a/Desktop.Shared/Startup/IServiceProviderExtensions.cs
+++ b/Desktop.Shared/Startup/IServiceProviderExtensions.cs
@@ -154,8 +154,6 @@ public static class IServiceProviderExtensions
             commandLine,
             -1,
             false,
-            "default",
-            true,
             out var procInfo);
         Console.WriteLine($"Elevate result: {result}. Process ID: {procInfo.dwProcessId}.");
         Environment.Exit(0);


### PR DESCRIPTION
This PR causes the "desktop" process to launch into the Winlogon desktop when "LogonUI.exe" or "consent.exe" is present in the target session.

This allows remote control consent and chat to work when the user is on the Windows logon screen.  Or if they somehow got stuck in full-screen UAC.  🤷

![image](https://github.com/user-attachments/assets/c7d7efa5-5cbd-4096-bfea-5fb2a94cc965)

Closes #920 

---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
