### PR TITLE
Add ability to save network ranges (using cidr notation) to knownProxies

### DIFF
--- a/Server/Components/Pages/ServerConfig.razor.cs
+++ b/Server/Components/Pages/ServerConfig.razor.cs
@@ -105,13 +105,34 @@ public partial class ServerConfig : AuthComponentBase
 
     private void AddKnownProxy()
     {
+        // Ensure _knownProxyToAdd is not null or empty before proceeding
+        if (string.IsNullOrEmpty(_knownProxyToAdd))
+        {
+            ToastService.ShowToast2("Input cannot be null or empty.", Enums.ToastType.Warning);
+            return;
+        }
         if (IPAddress.TryParse(_knownProxyToAdd, out _))
         {
             Input.KnownProxies.Add(_knownProxyToAdd);
         }
-        else
+       else
         {
-            ToastService.ShowToast2("Invalid IP address.", Enums.ToastType.Warning);
+        // Allow for CIDR in Known Proxies
+        // If it's not an IP, attempt to parse it as a CIDR block (e.g., 192.168.1.0/24)
+        try
+        {
+            var network = IPNetwork.Parse(_knownProxyToAdd);
+
+            // Convert the IPNetwork object to a string (CIDR format)
+            string networkString = network.ToString();
+
+            Input.KnownProxies.Add(networkString);
+        }
+        catch (FormatException)
+        {
+            // If it's neither a valid IP nor a valid CIDR block, show a warning toast
+            ToastService.ShowToast2("Invalid IP address or CIDR format.", Enums.ToastType.Warning);
+        }
         }
 
         _knownProxyToAdd = string.Empty;

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -184,6 +184,22 @@ services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.KnownProxies.Add(ip);
             }
+            // Allow for CIDR in Known Proxies
+            else
+            {
+                // Try to parse the CIDR address
+                try
+                {
+                    var network = Microsoft.AspNetCore.HttpOverrides.IPNetwork.Parse(proxy);
+                    options.KnownNetworks.Add(network); // Add the network to KnownNetworks
+                }
+                catch (FormatException)
+                {
+                    // Handle invalid CIDR format gracefully
+                    // Log or throw an exception as needed
+                    Console.WriteLine($"Invalid CIDR format: {proxy}");
+                }
+            }
         }
     }
 });


### PR DESCRIPTION
---
Please read the following.  Do not delete below this line.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to Immense Networks so we retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that we'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Immense Networks, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
